### PR TITLE
feat(auth): add generic OIDC provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,14 @@ AUTH_TRUSTED_ORIGINS=http://localhost:3003,http://127.0.0.1:3003 # Additional tr
 # (Optional) Sign in w/ GitHub Configuration
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
+# (Optional) Sign in w/ a generic OIDC provider (Pocket ID, Authelia, Authentik, Keycloak, ...)
+# Callback URL to register with the provider: <BASE_URL>/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_DISCOVERY_URL=
+# OIDC_PROVIDER_ID=oidc
+# OIDC_PROVIDER_NAME=SSO
+# OIDC_SCOPES=openid profile email
 
 # (Optional) Comma-separated list of emails that are auto-promoted to admin.
 ADMIN_EMAILS=

--- a/docs-site/docs/configure/auth.md
+++ b/docs-site/docs/configure/auth.md
@@ -11,6 +11,22 @@ This page covers application-level configuration for provider access and authent
 - Anonymous auth sessions are disabled by default.
 - Set `USE_ANONYMOUS_AUTH_SESSIONS=true` to enable anonymous session flows.
 
+## Single sign-on (OAuth / OIDC)
+
+Alongside email/password, two optional SSO methods are supported. Each appears on the sign-in page only when configured:
+
+- **GitHub** — set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`. The OAuth callback URL to register with GitHub is `<BASE_URL>/api/auth/callback/github`.
+- **Generic OIDC** — for self-hosted identity providers (Pocket ID, Authelia, Authentik, Keycloak, etc.). Set `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, and `OIDC_DISCOVERY_URL` (the provider's `/.well-known/openid-configuration` URL). The callback URL to register with your provider is `<BASE_URL>/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>` (`oidc` unless you override `OIDC_PROVIDER_ID`). Optional: `OIDC_PROVIDER_NAME` labels the sign-in button (defaults to `SSO`), and `OIDC_SCOPES` overrides the requested scopes (defaults to `openid profile email`).
+
+```env
+OIDC_CLIENT_ID=your-client-id
+OIDC_CLIENT_SECRET=your-client-secret
+OIDC_DISCOVERY_URL=https://auth.example.com/.well-known/openid-configuration
+OIDC_PROVIDER_NAME=Pocket ID
+```
+
+OIDC sign-ins are trusted for account linking: a user who originally signed up with email/password and later signs in through your identity provider with the same email address is attached to their existing account, keeping their documents and settings. OpenReader does not verify local email addresses. The IdP's email claim serves as ownership proof — only enable OIDC against an identity provider you operate and trust.
+
 ## Runtime modes
 
 OpenReader has two common runtime modes:

--- a/docs-site/docs/reference/environment-variables.md
+++ b/docs-site/docs/reference/environment-variables.md
@@ -25,6 +25,12 @@ Runtime site features are seeded with `RUNTIME_SEED_JSON` / `RUNTIME_SEED_JSON_P
 | `USE_ANONYMOUS_AUTH_SESSIONS` | Auth | `false` | Set `true` to allow anonymous auth sessions |
 | `GITHUB_CLIENT_ID` | Auth/OAuth | unset | Set with `GITHUB_CLIENT_SECRET` to enable GitHub sign-in |
 | `GITHUB_CLIENT_SECRET` | Auth/OAuth | unset | Set with `GITHUB_CLIENT_ID` to enable GitHub sign-in |
+| `OIDC_CLIENT_ID` | Auth/OAuth | unset | Set with `OIDC_CLIENT_SECRET` and `OIDC_DISCOVERY_URL` to enable generic OIDC sign-in |
+| `OIDC_CLIENT_SECRET` | Auth/OAuth | unset | OIDC client secret |
+| `OIDC_DISCOVERY_URL` | Auth/OAuth | unset | OIDC provider `/.well-known/openid-configuration` URL |
+| `OIDC_PROVIDER_ID` | Auth/OAuth | `oidc` | URL-safe id used in the OAuth callback path |
+| `OIDC_PROVIDER_NAME` | Auth/OAuth | `SSO` | Display name on the sign-in button |
+| `OIDC_SCOPES` | Auth/OAuth | `openid profile email` | Space- or comma-separated scopes |
 | `ADMIN_EMAILS` | Admin | empty | Comma-separated emails auto-promoted to admin |
 | `CRON_SECRET` | Scheduled tasks | unset | Required for Vercel cron invocations |
 | `POSTGRES_URL` | Database | unset (SQLite mode) | Set to switch metadata/auth DB to Postgres |
@@ -137,6 +143,41 @@ GitHub OAuth client ID.
 GitHub OAuth client secret.
 
 - Set with `GITHUB_CLIENT_ID`
+
+### OIDC_CLIENT_ID
+
+Client ID for a generic OIDC provider (Pocket ID, Authelia, Authentik, Keycloak, etc.).
+
+- Set with `OIDC_CLIENT_SECRET` and `OIDC_DISCOVERY_URL` to enable OIDC sign-in
+
+### OIDC_CLIENT_SECRET
+
+Client secret for the OIDC provider.
+
+- Set with `OIDC_CLIENT_ID` and `OIDC_DISCOVERY_URL`
+
+### OIDC_DISCOVERY_URL
+
+The provider's OIDC discovery document URL, e.g. `https://auth.example.com/.well-known/openid-configuration`. Endpoints are resolved from the discovery document.
+
+### OIDC_PROVIDER_ID
+
+URL-safe identifier for the provider (letters, numbers, hyphens, underscores).
+
+- Default: `oidc`
+- Forms the OAuth callback path: `<BASE_URL>/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>`
+
+### OIDC_PROVIDER_NAME
+
+Display name shown on the sign-in button ("Sign in with …").
+
+- Default: `SSO`
+
+### OIDC_SCOPES
+
+Space- or comma-separated OAuth scopes to request.
+
+- Default: `openid profile email`
 
 ### ADMIN_EMAILS
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,7 +5,7 @@ import { Toaster } from 'react-hot-toast';
 import { Providers } from '@/app/providers';
 import { ConfigProvider } from '@/contexts/ConfigContext';
 import { AppMain, AppShell } from '@/components/layout';
-import { getAuthBaseUrl, isAnonymousAuthSessionsEnabled, isGithubAuthEnabled } from '@/lib/server/auth/config';
+import { getAuthBaseUrl, getOidcPublicAuthConfig, isAnonymousAuthSessionsEnabled, isGithubAuthEnabled } from '@/lib/server/auth/config';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,12 +27,14 @@ export default function AppLayout({ children }: { children: ReactNode }) {
   const authBaseUrl = getAuthBaseUrl();
   const allowAnonymousAuthSessions = isAnonymousAuthSessionsEnabled();
   const githubAuthEnabled = isGithubAuthEnabled();
+  const oidcAuth = getOidcPublicAuthConfig();
 
   return (
     <Providers
       authBaseUrl={authBaseUrl}
       allowAnonymousAuthSessions={allowAnonymousAuthSessions}
       githubAuthEnabled={githubAuthEnabled}
+      oidcAuth={oidcAuth}
     >
       {/* Keep the preferences query/context mounted across library and reader navigation. */}
       <ConfigProvider>

--- a/src/app/(app)/signin/page.tsx
+++ b/src/app/(app)/signin/page.tsx
@@ -7,7 +7,7 @@ import { getAuthClient } from '@/lib/client/auth-client';
 import { useAuthConfig, useAuthRateLimit } from '@/contexts/AuthRateLimitContext';
 import { useFeatureFlag } from '@/contexts/RuntimeConfigContext';
 import { showPrivacyModal } from '@/components/PrivacyModal';
-import { GithubIcon } from '@/components/icons/Icons';
+import { GithubIcon, KeyIcon } from '@/components/icons/Icons';
 import { LoadingSpinner } from '@/components/Spinner';
 import { Button, Checkbox, Field, InlineButton, Input, Surface } from '@/components/ui';
 
@@ -26,15 +26,16 @@ function SignInContent() {
   const [password, setPassword] = useState('');
   const [loadingEmail, setLoadingEmail] = useState(false);
   const [loadingGithub, setLoadingGithub] = useState(false);
+  const [loadingOidc, setLoadingOidc] = useState(false);
   const [loadingAnonymous, setLoadingAnonymous] = useState(false);
   const [rememberMe, setRememberMe] = useState(true);
   const [sessionExpired, setSessionExpired] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { baseUrl, allowAnonymousAuthSessions, githubAuthEnabled } = useAuthConfig();
+  const { baseUrl, allowAnonymousAuthSessions, githubAuthEnabled, oidcAuth } = useAuthConfig();
   const enableUserSignups = useFeatureFlag('enableUserSignups');
   const { refresh: refreshRateLimit } = useAuthRateLimit();
 
-  const isAnyLoading = loadingEmail || loadingGithub || loadingAnonymous;
+  const isAnyLoading = loadingEmail || loadingGithub || loadingOidc || loadingAnonymous;
 
   const validateEmail = (email: string): boolean => {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -94,6 +95,20 @@ function SignInContent() {
       });
     } finally {
       setLoadingGithub(false);
+    }
+  };
+
+  const handleOidcSignIn = async () => {
+    if (!oidcAuth) return;
+    setLoadingOidc(true);
+    try {
+      const client = getAuthClient(baseUrl);
+      await client.signIn.oauth2({
+        providerId: oidcAuth.providerId,
+        callbackURL: '/app'
+      });
+    } finally {
+      setLoadingOidc(false);
     }
   };
 
@@ -204,6 +219,27 @@ function SignInContent() {
               <>
                 <GithubIcon className="w-4 h-4" />
                 Sign in with GitHub
+              </>
+            )}
+          </Button>
+          )}
+
+          {/* Generic OIDC */}
+          {oidcAuth && (
+          <Button
+            type="button"
+            disabled={isAnyLoading}
+            onClick={handleOidcSignIn}
+            variant="outline"
+            size="md"
+            className="w-full gap-2"
+          >
+            {loadingOidc ? (
+              <LoadingSpinner className="w-4 h-4" />
+            ) : (
+              <>
+                <KeyIcon className="w-4 h-4" />
+                Sign in with {oidcAuth.providerName}
               </>
             )}
           </Button>

--- a/src/app/(app)/signin/page.tsx
+++ b/src/app/(app)/signin/page.tsx
@@ -100,13 +100,20 @@ function SignInContent() {
 
   const handleOidcSignIn = async () => {
     if (!oidcAuth) return;
+    setError(null);
     setLoadingOidc(true);
     try {
       const client = getAuthClient(baseUrl);
-      await client.signIn.oauth2({
+      const result = await client.signIn.oauth2({
         providerId: oidcAuth.providerId,
         callbackURL: '/app'
       });
+      if (result.error) {
+        setError(result.error.message || 'Unable to connect. Please try again.');
+      }
+    } catch (err) {
+      console.error('OIDC sign in error:', err);
+      setError('Unable to connect. Please try again.');
     } finally {
       setLoadingOidc(false);
     }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,7 +4,7 @@ import { ReactNode, useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { ThemeProvider } from '@/contexts/ThemeContext';
-import { AuthRateLimitProvider } from '@/contexts/AuthRateLimitContext';
+import { AuthRateLimitProvider, type OidcAuthPublicConfig } from '@/contexts/AuthRateLimitContext';
 import { RuntimeConfigProvider } from '@/contexts/RuntimeConfigContext';
 import { AuthLoader } from '@/components/auth/AuthLoader';
 
@@ -13,9 +13,10 @@ interface ProvidersProps {
   authBaseUrl: string | null;
   allowAnonymousAuthSessions: boolean;
   githubAuthEnabled: boolean;
+  oidcAuth: OidcAuthPublicConfig | null;
 }
 
-export function Providers({ children, authBaseUrl, allowAnonymousAuthSessions, githubAuthEnabled }: ProvidersProps) {
+export function Providers({ children, authBaseUrl, allowAnonymousAuthSessions, githubAuthEnabled, oidcAuth }: ProvidersProps) {
   const [queryClient] = useState(() => new QueryClient({
     defaultOptions: {
       queries: {
@@ -50,6 +51,7 @@ export function Providers({ children, authBaseUrl, allowAnonymousAuthSessions, g
           authBaseUrl={authBaseUrl}
           allowAnonymousAuthSessions={allowAnonymousAuthSessions}
           githubAuthEnabled={githubAuthEnabled}
+          oidcAuth={oidcAuth}
         >
           <ThemeProvider>
             <AuthLoader>

--- a/src/contexts/AuthRateLimitContext.tsx
+++ b/src/contexts/AuthRateLimitContext.tsx
@@ -15,11 +15,17 @@ export interface RateLimitStatus {
   userType: 'anonymous' | 'authenticated' | 'unauthenticated';
 }
 
+export interface OidcAuthPublicConfig {
+  providerId: string;
+  providerName: string;
+}
+
 interface AuthRateLimitContextType {
   // Auth Config
   authBaseUrl: string | null;
   allowAnonymousAuthSessions: boolean;
   githubAuthEnabled: boolean;
+  oidcAuth: OidcAuthPublicConfig | null;
 
   // Rate Limit
   status: RateLimitStatus | null;
@@ -45,8 +51,8 @@ export function useAuthRateLimit(): AuthRateLimitContextType {
 }
 
 export function useAuthConfig() {
-  const { authBaseUrl, allowAnonymousAuthSessions, githubAuthEnabled } = useAuthRateLimit();
-  return { baseUrl: authBaseUrl, allowAnonymousAuthSessions, githubAuthEnabled };
+  const { authBaseUrl, allowAnonymousAuthSessions, githubAuthEnabled, oidcAuth } = useAuthRateLimit();
+  return { baseUrl: authBaseUrl, allowAnonymousAuthSessions, githubAuthEnabled, oidcAuth };
 }
 
 export function useRateLimit() {
@@ -107,6 +113,7 @@ interface AuthRateLimitProviderProps {
   authBaseUrl: string | null;
   allowAnonymousAuthSessions: boolean;
   githubAuthEnabled: boolean;
+  oidcAuth: OidcAuthPublicConfig | null;
 }
 
 export function AuthRateLimitProvider({
@@ -114,6 +121,7 @@ export function AuthRateLimitProvider({
   authBaseUrl,
   allowAnonymousAuthSessions,
   githubAuthEnabled,
+  oidcAuth,
 }: AuthRateLimitProviderProps) {
   const queryClient = useQueryClient();
   // Read the session directly from the prop-provided base URL. We can't use
@@ -221,6 +229,7 @@ export function AuthRateLimitProvider({
     authBaseUrl,
     allowAnonymousAuthSessions,
     githubAuthEnabled,
+    oidcAuth,
     status,
     loading,
     error,

--- a/src/lib/client/auth-client.ts
+++ b/src/lib/client/auth-client.ts
@@ -1,11 +1,11 @@
 import { createAuthClient } from "better-auth/react";
-import { anonymousClient } from "better-auth/client/plugins";
+import { anonymousClient, genericOAuthClient } from "better-auth/client/plugins";
 
 // Factory function to create auth client with specific baseUrl
 function createAuthClientWithUrl(baseUrl: string) {
   return createAuthClient({
     baseURL: baseUrl,
-    plugins: [anonymousClient()],
+    plugins: [anonymousClient(), genericOAuthClient()],
   });
 }
 

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -1,11 +1,11 @@
 import { betterAuth } from "better-auth";
 import { nextCookies } from "better-auth/next-js";
-import { anonymous } from "better-auth/plugins";
+import { anonymous, genericOAuth } from "better-auth/plugins";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { db } from "@openreader/database";
-import { getRequiredAuthEnv, isAnonymousAuthSessionsEnabled } from "@/lib/server/auth/config";
+import { getOidcAuthConfig, getRequiredAuthEnv, isAnonymousAuthSessionsEnabled } from "@/lib/server/auth/config";
 import { isAdminEmail, syncAdminFlag } from "@/lib/server/admin/email-sync";
 import { getResolvedRuntimeConfig } from '@/lib/server/runtime-config';
 import { assertUserSignupAllowed } from '@/lib/server/auth/signup-policy';
@@ -52,6 +52,7 @@ function envFlagEnabled(name: string, defaultValue: boolean): boolean {
 
 const authSchema = process.env.POSTGRES_URL ? authSchemaPostgres : authSchemaSqlite;
 const requiredAuthEnv = getRequiredAuthEnv();
+const oidcAuthConfig = getOidcAuthConfig();
 
 const createAuth = () => betterAuth({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -137,6 +138,26 @@ const createAuth = () => betterAuth({
       },
     }),
   },
+  ...(oidcAuthConfig && {
+    account: {
+      accountLinking: {
+        enabled: true,
+        // Let OIDC sign-ins attach to an existing account with the same
+        // email (e.g. a user who originally signed up with email/password)
+        // instead of failing with "account already exists".
+        trustedProviders: [oidcAuthConfig.providerId],
+        // OpenReader never verifies local emails (`requireEmailVerification`
+        // is false and no verification emails are sent), so Better Auth's
+        // default of requiring `emailVerified: true` on the local row would
+        // permanently block linking for every email/password user. Rely on
+        // the trusted IdP's email claim as ownership proof instead. Note the
+        // trade-off: an unverified local account at some email can be linked
+        // by whoever owns that email at the IdP — acceptable when the IdP is
+        // operated by the same admin deploying OpenReader.
+        requireLocalEmailVerified: false,
+      },
+    },
+  }),
   session: {
     expiresIn: 60 * 60 * 24 * 7, // 7 days (reasonable for user experience)
     updateAge: 60 * 60 * 1, // 1 hour (refresh more frequently)
@@ -191,6 +212,21 @@ const createAuth = () => betterAuth({
             }
             // Note: Anonymous user will be automatically deleted after this callback completes
           },
+        }),
+      ]
+      : []),
+    ...(oidcAuthConfig
+      ? [
+        genericOAuth({
+          config: [
+            {
+              providerId: oidcAuthConfig.providerId,
+              clientId: oidcAuthConfig.clientId,
+              clientSecret: oidcAuthConfig.clientSecret,
+              discoveryUrl: oidcAuthConfig.discoveryUrl,
+              scopes: oidcAuthConfig.scopes,
+            },
+          ],
         }),
       ]
       : []),

--- a/src/lib/server/auth/config.ts
+++ b/src/lib/server/auth/config.ts
@@ -48,6 +48,57 @@ export function isGithubAuthEnabled(): boolean {
   return !!(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET);
 }
 
+export type OidcAuthConfig = {
+  providerId: string;
+  providerName: string;
+  clientId: string;
+  clientSecret: string;
+  discoveryUrl: string;
+  scopes: string[];
+};
+
+/**
+ * Public subset of the OIDC config that is safe to send to the client
+ * (never include the client secret here).
+ */
+export type OidcPublicAuthConfig = Pick<OidcAuthConfig, 'providerId' | 'providerName'>;
+
+/**
+ * Generic OIDC sign-in is available when OIDC_CLIENT_ID, OIDC_CLIENT_SECRET,
+ * and OIDC_DISCOVERY_URL are all set. Optional overrides:
+ * - OIDC_PROVIDER_ID: URL-safe id used in the OAuth callback path
+ *   (`/api/auth/oauth2/callback/<id>`), defaults to "oidc"
+ * - OIDC_PROVIDER_NAME: display name for the sign-in button, defaults to "SSO"
+ * - OIDC_SCOPES: space- or comma-separated, defaults to "openid profile email"
+ */
+export function getOidcAuthConfig(): OidcAuthConfig | null {
+  const clientId = process.env.OIDC_CLIENT_ID?.trim();
+  const clientSecret = process.env.OIDC_CLIENT_SECRET?.trim();
+  const discoveryUrl = process.env.OIDC_DISCOVERY_URL?.trim();
+  if (!clientId || !clientSecret || !discoveryUrl) return null;
+
+  const providerId = process.env.OIDC_PROVIDER_ID?.trim() || 'oidc';
+  if (!/^[a-zA-Z0-9_-]+$/.test(providerId)) {
+    throw new Error(
+      'Invalid OIDC_PROVIDER_ID: it becomes part of the OAuth callback URL '
+      + 'and may only contain letters, numbers, hyphens, and underscores.',
+    );
+  }
+
+  const providerName = process.env.OIDC_PROVIDER_NAME?.trim() || 'SSO';
+  const scopes = (process.env.OIDC_SCOPES?.trim() || 'openid profile email')
+    .split(/[\s,]+/)
+    .filter(Boolean);
+
+  return { providerId, providerName, clientId, clientSecret, discoveryUrl, scopes };
+}
+
+export function getOidcPublicAuthConfig(): OidcPublicAuthConfig | null {
+  const config = getOidcAuthConfig();
+  if (!config) return null;
+  return { providerId: config.providerId, providerName: config.providerName };
+}
+
 /**
  * Get the required auth base URL.
  */

--- a/tests/unit/auth-config.vitest.spec.ts
+++ b/tests/unit/auth-config.vitest.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { getAuthBaseUrl, getRequiredAuthEnv, isAnonymousAuthSessionsEnabled, isGithubAuthEnabled } from '../../src/lib/server/auth/config';
+import { getAuthBaseUrl, getOidcAuthConfig, getOidcPublicAuthConfig, getRequiredAuthEnv, isAnonymousAuthSessionsEnabled, isGithubAuthEnabled } from '../../src/lib/server/auth/config';
 import { withEnv } from './support/env';
 
 describe('auth config contract', () => {
@@ -89,5 +89,109 @@ describe('auth config contract', () => {
     await withEnv(env, async () => {
       expect(isGithubAuthEnabled()).toBe(expected);
     });
+  });
+
+  test.each([
+    {
+      title: 'returns null when OIDC client id is missing',
+      env: {
+        OIDC_CLIENT_ID: undefined,
+        OIDC_CLIENT_SECRET: 'secret',
+        OIDC_DISCOVERY_URL: 'https://idp.example.com/.well-known/openid-configuration',
+      },
+    },
+    {
+      title: 'returns null when OIDC client secret is missing',
+      env: {
+        OIDC_CLIENT_ID: 'id',
+        OIDC_CLIENT_SECRET: undefined,
+        OIDC_DISCOVERY_URL: 'https://idp.example.com/.well-known/openid-configuration',
+      },
+    },
+    {
+      title: 'returns null when OIDC discovery URL is missing',
+      env: {
+        OIDC_CLIENT_ID: 'id',
+        OIDC_CLIENT_SECRET: 'secret',
+        OIDC_DISCOVERY_URL: undefined,
+      },
+    },
+  ])('$title', async ({ env }) => {
+    await withEnv(env, async () => {
+      expect(getOidcAuthConfig()).toBeNull();
+      expect(getOidcPublicAuthConfig()).toBeNull();
+    });
+  });
+
+  test('OIDC config applies defaults for optional values', async () => {
+    await withEnv(
+      {
+        OIDC_CLIENT_ID: 'id',
+        OIDC_CLIENT_SECRET: 'secret',
+        OIDC_DISCOVERY_URL: 'https://idp.example.com/.well-known/openid-configuration',
+      },
+      async () => {
+        expect(getOidcAuthConfig()).toEqual({
+          providerId: 'oidc',
+          providerName: 'SSO',
+          clientId: 'id',
+          clientSecret: 'secret',
+          discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+          scopes: ['openid', 'profile', 'email'],
+        });
+      },
+    );
+  });
+
+  test('OIDC config honors optional overrides and scope parsing', async () => {
+    await withEnv(
+      {
+        OIDC_CLIENT_ID: 'id',
+        OIDC_CLIENT_SECRET: 'secret',
+        OIDC_DISCOVERY_URL: 'https://idp.example.com/.well-known/openid-configuration',
+        OIDC_PROVIDER_ID: 'pocket-id',
+        OIDC_PROVIDER_NAME: 'Pocket ID',
+        OIDC_SCOPES: 'openid, profile email',
+      },
+      async () => {
+        const config = getOidcAuthConfig();
+        expect(config).toMatchObject({
+          providerId: 'pocket-id',
+          providerName: 'Pocket ID',
+          scopes: ['openid', 'profile', 'email'],
+        });
+      },
+    );
+  });
+
+  test('OIDC public config exposes only provider id and name', async () => {
+    await withEnv(
+      {
+        OIDC_CLIENT_ID: 'id',
+        OIDC_CLIENT_SECRET: 'secret',
+        OIDC_DISCOVERY_URL: 'https://idp.example.com/.well-known/openid-configuration',
+        OIDC_PROVIDER_NAME: 'Pocket ID',
+      },
+      async () => {
+        expect(getOidcPublicAuthConfig()).toEqual({
+          providerId: 'oidc',
+          providerName: 'Pocket ID',
+        });
+      },
+    );
+  });
+
+  test('OIDC config rejects provider ids that are not URL-safe', async () => {
+    await withEnv(
+      {
+        OIDC_CLIENT_ID: 'id',
+        OIDC_CLIENT_SECRET: 'secret',
+        OIDC_DISCOVERY_URL: 'https://idp.example.com/.well-known/openid-configuration',
+        OIDC_PROVIDER_ID: 'bad/provider id',
+      },
+      async () => {
+        expect(() => getOidcAuthConfig()).toThrow(/OIDC_PROVIDER_ID/);
+      },
+    );
   });
 });


### PR DESCRIPTION
This PR adds optional sign-in via any spec-compliant OIDC provider (Pocket ID, Authelia, Authentik, Keycloak, …) alongside email/password and GitHub, using better-auth's first-party genericOAuth plugin. 

**Configuration**: this feature is entirely env-gated with zero impact when unset.
Required to be set:
- `OIDC_CLIENT_ID`
- `OIDC_CLIENT_SECRET`
- `OIDC_DISCOVERY_URL`

Optional:
- `OIDC_PROVIDER_ID` (defaults to `oidc`, forms the callback path `/api/auth/oauth2/callback/<id>`)
- OIDC_PROVIDER_NAME (button label, default "SSO")
- OIDC_SCOPES (default `openid profile email`).

**Implementation**: mirrors the existing GitHub provider end to end as close as possible: 
- conditional plugin registration in `auth.ts`
- `genericOAuthClient()` on the client
- public-only config (`providerId`/`providerName`) wired up through the existing provider context
- sign-in button cloned from the GitHub one

I also updated the docs, the `.env.example`, and provided some basic unit tests for the env parsing.

One thing to call out: when OIDC is configured, account linking sets `requireLocalEmailVerified: false` scoped with `trustedProviders: [providerId]`.  

As of now, OpenReader doesn't verify local emails (`requireEmailVerification: false`, and no verification emails exist), so `better-auth's` default here silently blocks linking OIDC sign-ins to every existing email/password account. The failure to link is invisible if the user has a live session cookie (`?error=account_not_linked` is ignored by `/app`).  I found this out testing against my own Pocket ID instance. 

This is documented in the auth docs; happy to gate it behind another env var if you'd like.

**Testing**: unit tests pass, `tsc/ESLint` is clean, and the branch is deployed on my own instance against a live Pocket ID IdP and working. After signing out and logging back in through Pocket ID, the sign-in was successfully linked to my existing email/password account and all my documents and reading progress were still there. I also checked that the client secret never shows up in anything served to the browser, and that everything behaves exactly as before with all of the env vars empty/not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional generic OIDC single sign-on with configurable provider details and scopes.
  - OIDC sign-in appears on the login page when configured.
  - Added clearer messages for unlinked, pending, suspended, and failed SSO attempts.
  - Account linking now requires verified email claims from the provider and a verified local email address.

- **Bug Fixes**
  - Restricted OIDC discovery URLs to HTTPS, except for localhost development.

- **Documentation**
  - Documented OIDC setup, callback URLs, account-linking requirements, and environment variables.

- **Tests**
  - Added coverage for configuration defaults, overrides, validation, and incomplete setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->