### PR TITLE
fix: keep playback ahead under production latency

### DIFF
--- a/packages/compute-worker/src/api/playback/session-controller.ts
+++ b/packages/compute-worker/src/api/playback/session-controller.ts
@@ -1,7 +1,10 @@
 import { hashOpKey } from '../../infrastructure/nats-adapters';
 import type { WorkerOperationRequest } from '../../operations/contracts';
 import { buildTtsPlaybackOperationKey } from '../../operations/keys';
-import { generationFloorForCursor } from '../../playback/generation-window';
+import {
+  DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW,
+  generationFloorForCursor,
+} from '../../playback/generation-window';
 import { ttsPlaybackOperationCreateSchema } from '../schemas';
 import type { ComputeWorkerRouteContext } from '../route-context';
 import { isTerminalStatus, toErrorMessage } from '../route-context';
@@ -43,8 +46,13 @@ export function createPlaybackSessionController(
     if (session.playbackActive === false) return;
     if (now > session.expiresAt || !session.planObjectKey) return;
     const cursorOrdinal = Math.max(0, Math.floor(Number(session.cursorOrdinal ?? 0)));
-    const aheadWindow = Math.max(1, Math.floor(Number(session.aheadWindow ?? 8)));
-    const refillThreshold = Math.max(1, Math.floor(aheadWindow / 2));
+    const aheadWindow = Math.max(1, Math.floor(Number(
+      session.aheadWindow ?? DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW,
+    )));
+    // Refill while roughly three quarters of the window remains. Production
+    // queue, object-storage, and provider latency need more runway than the old
+    // half-window low-water mark provided.
+    const refillThreshold = Math.max(1, Math.ceil(aheadWindow * 0.75));
     const satisfiedFrom = session.generationSatisfiedFromOrdinal == null
       ? null
       : Math.max(0, Math.floor(Number(session.generationSatisfiedFromOrdinal)));
@@ -59,6 +67,7 @@ export function createPlaybackSessionController(
       && reason !== 'stream'
     ) return;
 
+    const hasSatisfiedWindow = satisfiedFrom !== null && satisfiedThrough !== null;
     if (session.workerOpId) {
       const current = await getOpState(session.workerOpId).catch((error) => {
         app.log.warn(
@@ -67,7 +76,11 @@ export function createPlaybackSessionController(
         );
         return null;
       });
-      if (current && !isTerminalStatus(current.status)) return;
+      // A nonterminal operation normally owns synthesis. Once it has published
+      // a satisfied window, however, it may only be draining best-effort exact
+      // alignment. Let low-water refill supersede that run so alignment cannot
+      // starve audible audio generation.
+      if (current && !isTerminalStatus(current.status) && !hasSatisfiedWindow) return;
     }
 
     // Cursor heartbeats and audio consumption are two signals for the same
@@ -103,6 +116,8 @@ export function createPlaybackSessionController(
     // segment boundary and exits without mutating the new run's terminal state.
     await playbackStorage.sessions.patchSession(session.sessionId, {
       generationRunId,
+      generationSatisfiedFromOrdinal: null,
+      generationSatisfiedThroughOrdinal: null,
       updatedAt: now,
     });
     const claimedSession = await readModel.readSession(session.sessionId);
@@ -125,6 +140,10 @@ export function createPlaybackSessionController(
       opId: op.opId,
       status: op.status,
       reason,
+      cursorOrdinal,
+      aheadWindow,
+      satisfiedFromOrdinal: satisfiedFrom,
+      satisfiedThroughOrdinal: satisfiedThrough,
       opKeyHash: hashOpKey(requestOp.opKey.trim()).slice(0, 16),
     }, 'tts.playback.resume_enqueued');
   };

--- a/packages/compute-worker/src/api/playback/session-controller.ts
+++ b/packages/compute-worker/src/api/playback/session-controller.ts
@@ -174,7 +174,7 @@ export function createPlaybackSessionController(
     async putSessionState(requestBody, status, workerOpId) {
       const now = Date.now();
       const startOrdinal = Math.max(0, Math.floor(Number(requestBody.planning.selectedOrdinal)));
-      await playbackStorage?.sessions.putSession({
+      await playbackStorage?.sessions.putSessionIfNewer({
         schemaVersion: 1,
         sessionId: requestBody.sessionId,
         userId: requestBody.userId,

--- a/packages/compute-worker/src/api/playback/session-controller.ts
+++ b/packages/compute-worker/src/api/playback/session-controller.ts
@@ -114,17 +114,25 @@ export function createPlaybackSessionController(
     // Claim the canonical session for this deterministic continuation before
     // enqueueing it. A superseded worker observes the changed run id at its next
     // segment boundary and exits without mutating the new run's terminal state.
-    await playbackStorage.sessions.patchSession(session.sessionId, {
-      generationRunId,
-      generationSatisfiedFromOrdinal: null,
-      generationSatisfiedThroughOrdinal: null,
-      updatedAt: now,
-    });
+    const claimed = await playbackStorage.sessions.patchSessionIfGenerationRun(
+      session.sessionId,
+      session.generationRunId ?? null,
+      {
+        generationRunId,
+        generationSatisfiedFromOrdinal: null,
+        generationSatisfiedThroughOrdinal: null,
+        updatedAt: now,
+      },
+    );
     const claimedSession = await readModel.readSession(session.sessionId);
-    if (!claimedSession || claimedSession.playbackActive === false) return;
+    if (
+      !claimedSession
+      || claimedSession.playbackActive === false
+      || claimedSession.generationRunId !== generationRunId
+    ) return;
     await ensureOrphanedOpRecovery();
     const op = await deps.orchestrator.enqueueOrReuse(requestOp);
-    await playbackStorage.sessions.patchSession(session.sessionId, {
+    await playbackStorage.sessions.patchSessionIfGenerationRun(session.sessionId, generationRunId, {
       status: op.status === 'failed' ? 'failed' : op.status === 'succeeded' ? 'succeeded' : 'running',
       workerOpId: op.opId,
       lastError: op.status === 'failed' ? (op.error?.message ?? 'Failed to enqueue playback continuation') : null,
@@ -144,6 +152,7 @@ export function createPlaybackSessionController(
       aheadWindow,
       satisfiedFromOrdinal: satisfiedFrom,
       satisfiedThroughOrdinal: satisfiedThrough,
+      claimReused: !claimed,
       opKeyHash: hashOpKey(requestOp.opKey.trim()).slice(0, 16),
     }, 'tts.playback.resume_enqueued');
   };

--- a/packages/compute-worker/src/api/routes/playback/sessions.ts
+++ b/packages/compute-worker/src/api/routes/playback/sessions.ts
@@ -215,12 +215,16 @@ export function registerPlaybackJobRoutes(
     };
     await ensureOrphanedOpRecovery();
     const op = await deps.orchestrator.enqueueOrReuse(requestOp);
-    await playbackStorage?.sessions.patchSession(parsed.data.sessionId, {
-      workerOpId: op.opId,
-      status: op.status === 'failed' ? 'failed' : op.status === 'succeeded' ? 'succeeded' : 'running',
-      lastError: op.status === 'failed' ? op.error?.message ?? 'Failed to enqueue playback operation' : null,
-      updatedAt: Date.now(),
-    }).catch((error) => {
+    await playbackStorage?.sessions.patchSessionIfGenerationRun(
+      parsed.data.sessionId,
+      parsed.data.generationRunId ?? null,
+      {
+        workerOpId: op.opId,
+        status: op.status === 'failed' ? 'failed' : op.status === 'succeeded' ? 'succeeded' : 'running',
+        lastError: op.status === 'failed' ? op.error?.message ?? 'Failed to enqueue playback operation' : null,
+        updatedAt: Date.now(),
+      },
+    ).catch((error) => {
       app.log.warn(
         { sessionId: parsed.data.sessionId, opId: op.opId, error: toErrorMessage(error) },
         'tts.playback.session_worker_op_patch_failed',

--- a/packages/compute-worker/src/inference/runtime.ts
+++ b/packages/compute-worker/src/inference/runtime.ts
@@ -14,12 +14,17 @@ export async function runWhisperAlignmentFromAudioBuffer(input: {
   cacheKey?: string;
   lang?: string;
   onModelDownloadProgress?: ModelDownloadProgressHandler;
+  shouldStart?: () => boolean | Promise<boolean>;
 }) {
   const alignments = await alignAudioWithText(
     input.audioBuffer,
     input.text,
     input.cacheKey,
-    { lang: input.lang, onModelDownloadProgress: input.onModelDownloadProgress },
+    {
+      lang: input.lang,
+      onModelDownloadProgress: input.onModelDownloadProgress,
+      shouldStart: input.shouldStart,
+    },
   );
   return { alignments };
 }

--- a/packages/compute-worker/src/inference/whisper/align.ts
+++ b/packages/compute-worker/src/inference/whisper/align.ts
@@ -60,6 +60,7 @@ interface WhisperAlignmentOptions {
   lang?: string;
   textHint?: string;
   onModelDownloadProgress?: ModelDownloadProgressHandler;
+  shouldStart?: () => boolean | Promise<boolean>;
 }
 
 interface WhisperRuntime {
@@ -86,6 +87,7 @@ type WhisperAlignmentState = {
   alignmentCache: Map<string, TTSSentenceAlignment[]>;
   alignmentInFlight: Map<string, Promise<TTSSentenceAlignment[]>>;
   runtimePromise: Promise<WhisperRuntime> | null;
+  alignmentLaneTail: Promise<void>;
   pendingAlignments: number;
   officialMelFilters: Float32Array[] | null;
   emptyPastFeedsTemplate: Record<string, ort.Tensor> | null;
@@ -95,11 +97,15 @@ const WHISPER_ALIGNMENT_STATE_KEY = '__openreaderWhisperAlignmentStateV1';
 const g = globalThis as typeof globalThis & Record<string, unknown>;
 const state = (() => {
   const existing = g[WHISPER_ALIGNMENT_STATE_KEY] as WhisperAlignmentState | undefined;
-  if (existing) return existing;
+  if (existing) {
+    existing.alignmentLaneTail ??= Promise.resolve();
+    return existing;
+  }
   const created: WhisperAlignmentState = {
     alignmentCache: new Map<string, TTSSentenceAlignment[]>(),
     alignmentInFlight: new Map<string, Promise<TTSSentenceAlignment[]>>(),
     runtimePromise: null,
+    alignmentLaneTail: Promise.resolve(),
     pendingAlignments: 0,
     officialMelFilters: null,
     emptyPastFeedsTemplate: null,
@@ -848,7 +854,8 @@ export async function alignAudioWithText(
   if (shared) return shared;
 
   state.pendingAlignments += 1;
-  const run = (async (): Promise<TTSSentenceAlignment[]> => {
+  const execute = async (): Promise<TTSSentenceAlignment[]> => {
+    if (opts.shouldStart && !await opts.shouldStart()) return [];
     const alignmentTimeoutMs = getAlignmentTimeoutMs();
     const deadlineMs = Date.now() + alignmentTimeoutMs;
     let tmpBase = '';
@@ -898,7 +905,12 @@ export async function alignAudioWithText(
       }
       state.pendingAlignments = Math.max(0, state.pendingAlignments - 1);
     }
-  })();
+  };
+  // ONNX alignment is CPU- and memory-intensive. Keep one process-wide lane,
+  // including across superseded playback runs, so a refill can prioritize new
+  // audio without multiplying Whisper pressure on a constrained worker.
+  const run = state.alignmentLaneTail.then(execute, execute);
+  state.alignmentLaneTail = run.then(() => undefined, () => undefined);
 
   alignmentInFlight.set(inFlightKey, run);
   const clearInFlight = () => {

--- a/packages/compute-worker/src/inference/whisper/align.ts
+++ b/packages/compute-worker/src/inference/whisper/align.ts
@@ -88,7 +88,6 @@ type WhisperAlignmentState = {
   alignmentInFlight: Map<string, Promise<TTSSentenceAlignment[]>>;
   runtimePromise: Promise<WhisperRuntime> | null;
   alignmentLaneTail: Promise<void>;
-  pendingAlignments: number;
   officialMelFilters: Float32Array[] | null;
   emptyPastFeedsTemplate: Record<string, ort.Tensor> | null;
 };
@@ -106,7 +105,6 @@ const state = (() => {
     alignmentInFlight: new Map<string, Promise<TTSSentenceAlignment[]>>(),
     runtimePromise: null,
     alignmentLaneTail: Promise.resolve(),
-    pendingAlignments: 0,
     officialMelFilters: null,
     emptyPastFeedsTemplate: null,
   };
@@ -853,9 +851,7 @@ export async function alignAudioWithText(
   const shared = alignmentInFlight.get(inFlightKey);
   if (shared) return shared;
 
-  state.pendingAlignments += 1;
   const execute = async (): Promise<TTSSentenceAlignment[]> => {
-    if (opts.shouldStart && !await opts.shouldStart()) return [];
     const alignmentTimeoutMs = getAlignmentTimeoutMs();
     const deadlineMs = Date.now() + alignmentTimeoutMs;
     let tmpBase = '';
@@ -863,6 +859,7 @@ export async function alignAudioWithText(
     let pcmPath = '';
 
     try {
+      if (opts.shouldStart && !await opts.shouldStart()) return [];
       tmpBase = await mkdtemp(join(tmpdir(), 'openreader-whisper-'));
       inputPath = join(tmpBase, `${randomUUID()}-input.bin`);
       pcmPath = join(tmpBase, `${randomUUID()}-input.pcm16`);
@@ -903,7 +900,6 @@ export async function alignAudioWithText(
       if (tmpBase) {
         await rm(tmpBase, { recursive: true, force: true }).catch(() => {});
       }
-      state.pendingAlignments = Math.max(0, state.pendingAlignments - 1);
     }
   };
   // ONNX alignment is CPU- and memory-intensive. Keep one process-wide lane,

--- a/packages/compute-worker/src/inference/whisper/model.ts
+++ b/packages/compute-worker/src/inference/whisper/model.ts
@@ -209,17 +209,6 @@ export async function ensureWhisperArtifacts(options: {
   }
 }
 
-export function createSingleflightRunner<T>(work: () => Promise<T>): () => Promise<T> {
-  let inflight: Promise<T> | null = null;
-  return async () => {
-    if (inflight) return inflight;
-    inflight = work().finally(() => {
-      inflight = null;
-    });
-    return inflight;
-  };
-}
-
 async function ensureModelInternal(onProgress?: ModelDownloadProgressHandler): Promise<string> {
   if (process.env[WHISPER_MODEL_BASE_URL_ENV]?.trim()) {
     for (const relativePath of MODEL_RELATIVE_PATHS) {

--- a/packages/compute-worker/src/infrastructure/nats-adapters.ts
+++ b/packages/compute-worker/src/infrastructure/nats-adapters.ts
@@ -36,7 +36,7 @@ export interface KvStoreLike {
   keys(filter?: string | string[]): Promise<AsyncIterable<string>>;
 }
 
-function isCasConflictError(error: unknown): boolean {
+export function isKvCasConflictError(error: unknown): boolean {
   const message = toErrorMessage(error).toLowerCase();
   return message.includes('wrong last sequence') || message.includes('key exists') || message.includes('wrong last');
 }
@@ -115,7 +115,7 @@ export class JetStreamOperationStateStore<Result = unknown> implements Operation
       );
       return true;
     } catch (error) {
-      if (isCasConflictError(error)) return false;
+      if (isKvCasConflictError(error)) return false;
       throw error;
     }
   }
@@ -153,7 +153,7 @@ export class JetStreamOperationStateStore<Result = unknown> implements Operation
         await kv.create(key, value);
         return true;
       } catch (error) {
-        if (isCasConflictError(error)) return false;
+        if (isKvCasConflictError(error)) return false;
         throw error;
       }
     }
@@ -167,7 +167,7 @@ export class JetStreamOperationStateStore<Result = unknown> implements Operation
       await kv.update(key, value, current.revision);
       return true;
     } catch (error) {
-      if (isCasConflictError(error)) return false;
+      if (isKvCasConflictError(error)) return false;
       throw error;
     }
   }

--- a/packages/compute-worker/src/jobs/model-download-progress.ts
+++ b/packages/compute-worker/src/jobs/model-download-progress.ts
@@ -1,0 +1,36 @@
+import type {
+  ModelDownloadProgress,
+  ModelDownloadProgressHandler,
+} from '../inference/model-download';
+
+export const MODEL_DOWNLOAD_PROGRESS_MIN_BYTES = 8 * 1024 * 1024;
+export const MODEL_DOWNLOAD_PROGRESS_MAX_INTERVAL_MS = 1_000;
+
+/**
+ * Keep model-download telemetry useful without putting durable operation-state
+ * writes in the hot path for every network chunk. The first, terminal, byte,
+ * and time checkpoints are still delivered in order.
+ */
+export function createModelDownloadProgressReporter(input: {
+  publish: ModelDownloadProgressHandler;
+  onObserved?: () => void;
+  now?: () => number;
+}): ModelDownloadProgressHandler {
+  let lastPublishedAt = 0;
+  let lastPublishedBytes = -1;
+  const now = input.now ?? Date.now;
+
+  return async (progress: ModelDownloadProgress) => {
+    input.onObserved?.();
+    const observedAt = now();
+    const shouldPublish = lastPublishedBytes < 0
+      || (progress.totalBytes > 0 && progress.downloadedBytes >= progress.totalBytes)
+      || progress.downloadedBytes - lastPublishedBytes >= MODEL_DOWNLOAD_PROGRESS_MIN_BYTES
+      || observedAt - lastPublishedAt >= MODEL_DOWNLOAD_PROGRESS_MAX_INTERVAL_MS;
+    if (!shouldPublish) return;
+
+    lastPublishedAt = observedAt;
+    lastPublishedBytes = progress.downloadedBytes;
+    await input.publish(progress);
+  };
+}

--- a/packages/compute-worker/src/jobs/pdf-layout.ts
+++ b/packages/compute-worker/src/jobs/pdf-layout.ts
@@ -3,6 +3,7 @@ import { runPdfLayoutFromPdfBuffer } from '../inference/runtime';
 import { withIdleTimeoutAndHardCap, withTimeout } from '../infrastructure/config';
 import type { PdfLayoutJobRequest, PdfLayoutJobResult, PdfLayoutProgress } from '../operations/contracts';
 import type { JobHandlerContext } from './context';
+import { createModelDownloadProgressReporter } from './model-download-progress';
 import { persistParsedPdfWhileSourceExists } from './pdf-artifact-persistence';
 import { buildInferProgressForPageParsed, buildInferProgressForPageStart } from './pdf-progress';
 
@@ -24,8 +25,6 @@ export function createPdfLayoutHandler(input: JobHandlerContext) {
     const s3FetchMs = Date.now() - s3FetchStartedAt;
     let lastTotalPages = 0;
     let lastPagesParsed = 0;
-    let lastModelProgressAt = 0;
-    let lastModelProgressBytes = -1;
     const computeStartedAt = Date.now();
     const result = await withIdleTimeoutAndHardCap({
       idleTimeoutMs: Math.max(input.pdfTimeoutMs, 1_000),
@@ -34,24 +33,18 @@ export function createPdfLayoutHandler(input: JobHandlerContext) {
       run: async (touchProgress) => runPdfLayoutFromPdfBuffer({
         documentId: parsed.documentId,
         pdfBytes,
-        onModelDownloadProgress: async ({ downloadedBytes, totalBytes }) => {
-          touchProgress();
-          const now = Date.now();
-          const shouldPublish = lastModelProgressBytes < 0
-            || downloadedBytes >= totalBytes
-            || downloadedBytes - lastModelProgressBytes >= 1024 * 1024
-            || now - lastModelProgressAt >= 500;
-          if (!shouldPublish) return;
-          lastModelProgressAt = now;
-          lastModelProgressBytes = downloadedBytes;
-          await hooks?.onProgress?.({
-            phase: 'download_model',
-            totalPages: 0,
-            pagesParsed: 0,
-            downloadedBytes,
-            totalBytes,
-          });
-        },
+        onModelDownloadProgress: createModelDownloadProgressReporter({
+          onObserved: touchProgress,
+          publish: async ({ downloadedBytes, totalBytes }) => {
+            await hooks?.onProgress?.({
+              phase: 'download_model',
+              totalPages: 0,
+              pagesParsed: 0,
+              downloadedBytes,
+              totalBytes,
+            });
+          },
+        }),
         onPageStarted: async ({ pageNumber, totalPages }) => {
           touchProgress();
           lastTotalPages = totalPages;

--- a/packages/compute-worker/src/jobs/playback/playback-job.ts
+++ b/packages/compute-worker/src/jobs/playback/playback-job.ts
@@ -1,11 +1,14 @@
 import type { TtsPlaybackJobRequest, TtsPlaybackJobResult, TtsPlaybackProgress } from '../../operations/contracts';
-import { generationFloorForCursor } from '../../playback/generation-window';
+import {
+  DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW,
+  generationFloorForCursor,
+} from '../../playback/generation-window';
 import type { JobHandlerContext } from '../context';
+import { createModelDownloadProgressReporter } from '../model-download-progress';
 import { resolveAndPersistTtsPlaybackPlan } from './plan';
 import { generateExplicitTtsPlaybackSegments } from './segment-generation';
 import { ttsPlaybackRequestSchema } from './schemas';
 
-const DEFAULT_AHEAD_WINDOW = 8;
 const CURSOR_STALE_MS = 15_000;
 
 function playbackSectionKey(locator: unknown, readerType: 'pdf' | 'epub' | 'html'): string | null {
@@ -91,7 +94,7 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
       });
 
       const lastOrdinal = plannedSegments.reduce((max, segment) => Math.max(max, segment.ordinal), -1);
-      const aheadWindow = parsed.aheadWindow ?? DEFAULT_AHEAD_WINDOW;
+      const aheadWindow = parsed.aheadWindow ?? DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW;
       const backgroundExtent = parsed.backgroundExtent ?? 'section';
       const forceDocumentExtent = parsed.generationExtent === 'document';
       const readCurrentCacheEpoch = async () => playbackStorage.artifacts.getScopeEpoch({
@@ -139,6 +142,20 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
       const satisfaction: {
         value: { fromOrdinal: number; throughOrdinal: number } | null;
       } = { value: null };
+      const persistSatisfiedWindowIfCurrent = async (): Promise<void> => {
+        const satisfiedWindow = satisfaction.value;
+        if (!satisfiedWindow) return;
+        const session = await playbackStorage.sessions.getSession(parsed.sessionId).catch(() => null);
+        if (
+          !session
+          || session.playbackActive === false
+          || (session.generationRunId ?? null) !== generationRunId
+        ) return;
+        await playbackStorage.sessions.patchSession(parsed.sessionId, {
+          generationSatisfiedFromOrdinal: satisfiedWindow.fromOrdinal,
+          generationSatisfiedThroughOrdinal: satisfiedWindow.throughOrdinal,
+        });
+      };
       let lastCompletedThrough = completedOrdinals.size > 0 ? Math.max(...completedOrdinals) : -1;
       const emitProgress = async (): Promise<void> => {
         await hooks?.onProgress?.({
@@ -202,8 +219,6 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
       const generationSegments = forceDocumentExtent
         ? plannedSegments
         : plannedSegments.filter((segment) => segment.ordinal >= generationFloor);
-      let lastModelProgressAt = 0;
-      let lastModelProgressBytes = -1;
       await generateExplicitTtsPlaybackSegments({
         request: parsed,
         s3Prefix: input.s3Prefix,
@@ -217,29 +232,22 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
         getCurrentCacheEpoch: readCurrentCacheEpoch,
         synthesisTimeoutMs: Math.max(input.ttsPlaybackSegmentTimeoutMs, 1_000),
         onBeforeSegment,
+        onSynthesisSettled: persistSatisfiedWindowIfCurrent,
         onSegmentCompleted,
         onSegmentErrored: async (planOrdinal) => {
           erroredOrdinals.add(planOrdinal);
           await emitProgress();
         },
-        onModelDownloadProgress: async ({ downloadedBytes, totalBytes }) => {
-          const now = Date.now();
-          const shouldPublish = lastModelProgressBytes < 0
-            || downloadedBytes >= totalBytes
-            || downloadedBytes - lastModelProgressBytes >= 1024 * 1024
-            || now - lastModelProgressAt >= 500;
-          if (!shouldPublish) return;
-          lastModelProgressAt = now;
-          lastModelProgressBytes = downloadedBytes;
-          await hooks?.onProgress?.({
+        onModelDownloadProgress: createModelDownloadProgressReporter({
+          publish: async ({ downloadedBytes, totalBytes }) => hooks?.onProgress?.({
             completedThroughOrdinal: lastCompletedThrough,
             completedCount: completedOrdinals.size,
             plannedCount: plannedSegments.length,
             phase: 'downloading_model',
             downloadedBytes,
             totalBytes,
-          });
-        },
+          }),
+        }),
       });
       const finalSession = await playbackStorage.sessions.getSession(parsed.sessionId).catch(() => null);
       const cacheEpochStillCurrent = await readCurrentCacheEpoch() === cacheEpoch;

--- a/packages/compute-worker/src/jobs/playback/playback-job.ts
+++ b/packages/compute-worker/src/jobs/playback/playback-job.ts
@@ -82,16 +82,27 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
       const isContinuationRun = Boolean(parsed.generationRunId);
       const sessionCursorOrdinal = Math.max(0, Math.floor(Number(currentSession.cursorOrdinal ?? startOrdinal)));
       const sessionCursorUpdatedAt = currentSession.cursorUpdatedAt == null ? null : Number(currentSession.cursorUpdatedAt);
-      await playbackStorage.sessions.patchSession(parsed.sessionId, {
-        status: 'running',
-        planObjectKey,
-        generationStartOrdinal: isContinuationRun
-          ? Math.max(0, Math.floor(Number(currentSession.generationStartOrdinal ?? startOrdinal)))
-          : startOrdinal,
-        cursorOrdinal: isContinuationRun ? sessionCursorOrdinal : startOrdinal,
-        cursorUpdatedAt: isContinuationRun ? sessionCursorUpdatedAt : Date.now(),
-        lastError: null,
-      });
+      const markedRunning = await playbackStorage.sessions.patchSessionIfGenerationRun(
+        parsed.sessionId,
+        generationRunId,
+        {
+          status: 'running',
+          planObjectKey,
+          generationStartOrdinal: isContinuationRun
+            ? Math.max(0, Math.floor(Number(currentSession.generationStartOrdinal ?? startOrdinal)))
+            : startOrdinal,
+          cursorOrdinal: isContinuationRun ? sessionCursorOrdinal : startOrdinal,
+          cursorUpdatedAt: isContinuationRun ? sessionCursorUpdatedAt : Date.now(),
+          lastError: null,
+        },
+      );
+      if (!markedRunning) {
+        return {
+          sessionId: parsed.sessionId,
+          planObjectKey,
+          timing: { queueWaitMs, computeMs: Date.now() - startedAt },
+        };
+      }
 
       const lastOrdinal = plannedSegments.reduce((max, segment) => Math.max(max, segment.ordinal), -1);
       const aheadWindow = parsed.aheadWindow ?? DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW;
@@ -145,13 +156,7 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
       const persistSatisfiedWindowIfCurrent = async (): Promise<void> => {
         const satisfiedWindow = satisfaction.value;
         if (!satisfiedWindow) return;
-        const session = await playbackStorage.sessions.getSession(parsed.sessionId).catch(() => null);
-        if (
-          !session
-          || session.playbackActive === false
-          || (session.generationRunId ?? null) !== generationRunId
-        ) return;
-        await playbackStorage.sessions.patchSession(parsed.sessionId, {
+        await playbackStorage.sessions.patchSessionIfGenerationRun(parsed.sessionId, generationRunId, {
           generationSatisfiedFromOrdinal: satisfiedWindow.fromOrdinal,
           generationSatisfiedThroughOrdinal: satisfiedWindow.throughOrdinal,
         });
@@ -274,13 +279,17 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
         && finalSession?.playbackActive !== false
         && (finalSession?.generationRunId ?? null) === generationRunId
       ) {
-        await playbackStorage.sessions.patchSession(parsed.sessionId, {
+        await playbackStorage.sessions.patchSessionIfGenerationRun(parsed.sessionId, generationRunId, {
           generationSatisfiedFromOrdinal: satisfiedWindow.fromOrdinal,
           generationSatisfiedThroughOrdinal: satisfiedWindow.throughOrdinal,
         });
       }
       if (!stoppedEarly) {
-        await playbackStorage.sessions.patchSession(parsed.sessionId, { status: 'succeeded', planObjectKey, lastError: null });
+        await playbackStorage.sessions.patchSessionIfGenerationRun(parsed.sessionId, generationRunId, {
+          status: 'succeeded',
+          planObjectKey,
+          lastError: null,
+        });
       }
       return { sessionId: parsed.sessionId, planObjectKey, timing: { queueWaitMs, computeMs: Date.now() - startedAt } };
     } catch (error) {
@@ -289,7 +298,7 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
         (latest?.status === 'queued' || latest?.status === 'running')
         && (latest.generationRunId ?? null) === generationRunId
       ) {
-        await playbackStorage.sessions.patchSession(parsed.sessionId, {
+        await playbackStorage.sessions.patchSessionIfGenerationRun(parsed.sessionId, generationRunId, {
           status: 'failed',
           lastError: error instanceof Error ? error.message : String(error),
         }).catch(() => undefined);

--- a/packages/compute-worker/src/jobs/playback/segment-generation.ts
+++ b/packages/compute-worker/src/jobs/playback/segment-generation.ts
@@ -99,6 +99,7 @@ export async function generateExplicitTtsPlaybackSegments(input: {
   getCurrentCacheEpoch?: () => Promise<number>;
   synthesisTimeoutMs: number;
   onBeforeSegment?: (planOrdinal: number) => Promise<'continue' | 'stop'>;
+  onSynthesisSettled?: () => Promise<void>;
   onSegmentCompleted?: (planOrdinal: number) => Promise<void>;
   onSegmentErrored?: (planOrdinal: number) => Promise<void>;
   onModelDownloadProgress?: ModelDownloadProgressHandler;
@@ -183,6 +184,7 @@ export async function generateExplicitTtsPlaybackSegments(input: {
     lang: effectiveSettings.language,
     cacheKey: audioKey,
     onModelDownloadProgress: input.onModelDownloadProgress,
+    shouldStart: () => shouldContinueWrites(segment.original.ordinal),
   }).then((result) => {
     const first = result.alignments[0];
     return first ? { ...first, sentenceIndex: segment.original.ordinal } : null;
@@ -315,7 +317,7 @@ export async function generateExplicitTtsPlaybackSegments(input: {
     if (audioExists) {
       if (!await shouldContinueWrites(planOrdinal)) break;
       let durationMs = existing?.status === 'completed' ? existing.durationMs : null;
-      let alignment = existing?.alignment ?? null;
+      const alignment = existing?.alignment ?? null;
       const needsRebuild = existing?.status !== 'completed' || durationMs == null || !alignment;
       let storedAudio: Buffer | null = null;
       if (needsRebuild && input.readAudioObject) {
@@ -448,6 +450,12 @@ export async function generateExplicitTtsPlaybackSegments(input: {
     }).catch(() => undefined);
     await input.onSegmentErrored?.(planOrdinal);
   }
+
+  // Audio production and best-effort exact alignment have different urgency.
+  // Tell the session controller that synthesis has reached its current boundary
+  // before waiting for the ordered alignment lane to drain, so an active reader
+  // can refill without being blocked by cold or CPU-constrained Whisper work.
+  await input.onSynthesisSettled?.();
 
   // Keep the job alive until queued best-effort timing has either completed or
   // observed that this playback run was paused/superseded.

--- a/packages/compute-worker/src/playback/generation-window.ts
+++ b/packages/compute-worker/src/playback/generation-window.ts
@@ -21,6 +21,7 @@
  * grind." The knob is kept so the trade-off can be revisited in one place.
  */
 export const TTS_PLAYBACK_BACKWARD_PAD = 0;
+export const DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW = 12;
 
 export function generationFloorForCursor(cursorOrdinal: number): number {
   const cursor = Math.max(0, Math.floor(Number(cursorOrdinal) || 0));

--- a/packages/compute-worker/src/playback/storage.ts
+++ b/packages/compute-worker/src/playback/storage.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import type { TTSSentenceAlignment } from '../operations/contracts';
 import type { ArtifactStorage } from '../infrastructure/storage';
 import { createJsonCodec } from '../infrastructure/json-codec';
-import type { KvStoreLike } from '../infrastructure/nats-adapters';
+import { isKvCasConflictError, type KvStoreLike } from '../infrastructure/nats-adapters';
 import { ttsPlaybackSegmentSidecarArtifactKey } from '../storage/artifact-addressing';
 
 export type TtsPlaybackSessionStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled';
@@ -82,6 +82,11 @@ export interface TtsPlaybackSessionStore {
   getSession(sessionId: string): Promise<TtsPlaybackSessionState | null>;
   putSession(state: TtsPlaybackSessionState): Promise<void>;
   patchSession(sessionId: string, patch: Partial<Omit<TtsPlaybackSessionState, 'schemaVersion' | 'sessionId'>>): Promise<void>;
+  patchSessionIfGenerationRun(
+    sessionId: string,
+    expectedGenerationRunId: string | null,
+    patch: Partial<Omit<TtsPlaybackSessionState, 'schemaVersion' | 'sessionId'>>,
+  ): Promise<boolean>;
   updateCursor(sessionId: string, ordinal: number, updatedAt?: number): Promise<void>;
   listSessions(scope?: TtsPlaybackResetScope): Promise<TtsPlaybackSessionState[]>;
   cancelSessionsForScope(scope: TtsPlaybackResetScope, updatedAt?: number): Promise<number>;
@@ -181,6 +186,37 @@ export function createTtsPlaybackKvStore(input: {
   const sessionCodec = createJsonCodec<TtsPlaybackSessionState>();
   const cursorCodec = createJsonCodec<TtsPlaybackCursorRecord>();
   const activityCodec = createJsonCodec<TtsPlaybackActivityRecord>();
+  const patchSessionRecord = async (
+    sessionId: string,
+    recordPatch: Partial<TtsPlaybackSessionState>,
+    expectedGenerationRunId?: string | null,
+  ): Promise<boolean> => {
+    const kv = await input.getKv();
+    const key = sessionKvKey(sessionId);
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const entry = await kv.get(key);
+      if (!isKvPut(entry)) return false;
+      const current = sessionCodec.decode(entry.value);
+      if (
+        expectedGenerationRunId !== undefined
+        && (current.generationRunId ?? null) !== expectedGenerationRunId
+      ) return false;
+      const next: TtsPlaybackSessionState = {
+        ...current,
+        ...recordPatch,
+        sessionId: current.sessionId,
+        schemaVersion: 1,
+        updatedAt: recordPatch.updatedAt ?? Date.now(),
+      };
+      try {
+        await kv.update(key, sessionCodec.encode(next), entry.revision);
+        return true;
+      } catch (error) {
+        if (!isKvCasConflictError(error)) throw error;
+      }
+    }
+    throw new Error(`Unable to update playback session ${sessionId} after repeated conflicts`);
+  };
   const listSessions = async (scope?: TtsPlaybackResetScope): Promise<TtsPlaybackSessionState[]> => {
     const kv = await input.getKv();
     const keys: string[] = [];
@@ -270,18 +306,15 @@ export function createTtsPlaybackKvStore(input: {
       // rewriting the record — the cursor key already carries a fresh timestamp.
       const meaningful = Object.keys(recordPatch).filter((field) => field !== 'updatedAt');
       if (meaningful.length === 0) return;
-      const key = sessionKvKey(sessionId);
-      const entry = await kv.get(key);
-      if (!isKvPut(entry)) return;
-      const current = sessionCodec.decode(entry.value);
-      const next: TtsPlaybackSessionState = {
-        ...current,
-        ...recordPatch,
-        sessionId: current.sessionId,
-        schemaVersion: 1,
-        updatedAt: recordPatch.updatedAt ?? Date.now(),
-      };
-      await kv.put(key, sessionCodec.encode(next));
+      await patchSessionRecord(sessionId, recordPatch);
+    },
+
+    async patchSessionIfGenerationRun(sessionId, expectedGenerationRunId, patch) {
+      const recordPatch: Partial<TtsPlaybackSessionState> = { ...patch };
+      delete recordPatch.cursorOrdinal;
+      delete recordPatch.cursorUpdatedAt;
+      delete recordPatch.playbackActive;
+      return patchSessionRecord(sessionId, recordPatch, expectedGenerationRunId);
     },
 
     async updateCursor(sessionId, ordinal, updatedAt = Date.now()) {

--- a/packages/compute-worker/src/playback/storage.ts
+++ b/packages/compute-worker/src/playback/storage.ts
@@ -166,6 +166,7 @@ function isResettableSessionStatus(status: TtsPlaybackSessionStatus): boolean {
 }
 
 interface TtsPlaybackCursorRecord {
+  sessionExpiresAt?: number;
   cursorOrdinal: number;
   cursorUpdatedAt: number | null;
 }
@@ -176,8 +177,13 @@ interface TtsPlaybackCacheEpochRecord {
 }
 
 interface TtsPlaybackActivityRecord {
+  sessionExpiresAt?: number;
   playbackActive: boolean;
   updatedAt: number;
+}
+
+function sidecarMatchesSession(sidecarExpiresAt: number | undefined, sessionExpiresAt: number): boolean {
+  return sidecarExpiresAt === undefined || sidecarExpiresAt === sessionExpiresAt;
 }
 
 export function createTtsPlaybackKvStore(input: {
@@ -236,12 +242,17 @@ export function createTtsPlaybackKvStore(input: {
         const cursorEntry = await kv.get(cursorKvKey(session.sessionId));
         if (isKvPut(cursorEntry)) {
           const cursor = cursorCodec.decode(cursorEntry.value);
-          session.cursorOrdinal = cursor.cursorOrdinal;
-          session.cursorUpdatedAt = cursor.cursorUpdatedAt;
+          if (sidecarMatchesSession(cursor.sessionExpiresAt, session.expiresAt)) {
+            session.cursorOrdinal = cursor.cursorOrdinal;
+            session.cursorUpdatedAt = cursor.cursorUpdatedAt;
+          }
         }
         const activityEntry = await kv.get(activityKvKey(session.sessionId));
         if (isKvPut(activityEntry)) {
-          session.playbackActive = activityCodec.decode(activityEntry.value).playbackActive;
+          const activity = activityCodec.decode(activityEntry.value);
+          if (sidecarMatchesSession(activity.sessionExpiresAt, session.expiresAt)) {
+            session.playbackActive = activity.playbackActive;
+          }
         }
       }));
     }
@@ -259,12 +270,17 @@ export function createTtsPlaybackKvStore(input: {
       const cursorEntry = await kv.get(cursorKvKey(sessionId));
       if (isKvPut(cursorEntry)) {
         const cursor = cursorCodec.decode(cursorEntry.value);
-        session.cursorOrdinal = cursor.cursorOrdinal;
-        session.cursorUpdatedAt = cursor.cursorUpdatedAt;
+        if (sidecarMatchesSession(cursor.sessionExpiresAt, session.expiresAt)) {
+          session.cursorOrdinal = cursor.cursorOrdinal;
+          session.cursorUpdatedAt = cursor.cursorUpdatedAt;
+        }
       }
       const activityEntry = await kv.get(activityKvKey(sessionId));
       if (isKvPut(activityEntry)) {
-        session.playbackActive = activityCodec.decode(activityEntry.value).playbackActive;
+        const activity = activityCodec.decode(activityEntry.value);
+        if (sidecarMatchesSession(activity.sessionExpiresAt, session.expiresAt)) {
+          session.playbackActive = activity.playbackActive;
+        }
       }
       return session;
     },
@@ -302,10 +318,12 @@ export function createTtsPlaybackKvStore(input: {
       }
       if (!accepted) throw new Error(`Unable to create playback session ${state.sessionId} after repeated conflicts`);
       await kv.put(cursorKvKey(state.sessionId), cursorCodec.encode({
+        sessionExpiresAt: state.expiresAt,
         cursorOrdinal: Math.max(0, Math.floor(state.cursorOrdinal)),
         cursorUpdatedAt: state.cursorUpdatedAt,
       }));
       await kv.put(activityKvKey(state.sessionId), activityCodec.encode({
+        sessionExpiresAt: state.expiresAt,
         playbackActive: state.playbackActive !== false,
         updatedAt: state.updatedAt,
       }));
@@ -314,8 +332,13 @@ export function createTtsPlaybackKvStore(input: {
 
     async patchSession(sessionId, patch) {
       const kv = await input.getKv();
+      const sessionEntry = await kv.get(sessionKvKey(sessionId));
+      const sessionExpiresAt = isKvPut(sessionEntry)
+        ? sessionCodec.decode(sessionEntry.value).expiresAt
+        : undefined;
       if (patch.playbackActive !== undefined) {
         await kv.put(activityKvKey(sessionId), activityCodec.encode({
+          ...(sessionExpiresAt === undefined ? {} : { sessionExpiresAt }),
           playbackActive: patch.playbackActive,
           updatedAt: patch.updatedAt ?? Date.now(),
         }));
@@ -324,6 +347,7 @@ export function createTtsPlaybackKvStore(input: {
       // never collides with the playhead heartbeat. Plain put, last-write-wins.
       if (patch.cursorOrdinal !== undefined && patch.cursorUpdatedAt !== undefined) {
         await kv.put(cursorKvKey(sessionId), cursorCodec.encode({
+          ...(sessionExpiresAt === undefined ? {} : { sessionExpiresAt }),
           cursorOrdinal: Math.max(0, Math.floor(patch.cursorOrdinal)),
           cursorUpdatedAt: patch.cursorUpdatedAt,
         }));
@@ -349,10 +373,15 @@ export function createTtsPlaybackKvStore(input: {
 
     async updateCursor(sessionId, ordinal, updatedAt = Date.now()) {
       const kv = await input.getKv();
-      // Pure last-write-wins put on the cursor's own key. No read, no CAS: a
-      // racing writer simply means newest-wins, the correct "where am I now"
-      // semantics for a playhead hint.
+      const sessionEntry = await kv.get(sessionKvKey(sessionId));
+      const sessionExpiresAt = isKvPut(sessionEntry)
+        ? sessionCodec.decode(sessionEntry.value).expiresAt
+        : undefined;
+      // Pure last-write-wins put on the cursor's own key. There is no CAS or
+      // shared session rewrite; the session expiry tag makes stale puts
+      // invisible if a newer canonical session wins while this write races.
       await kv.put(cursorKvKey(sessionId), cursorCodec.encode({
+        ...(sessionExpiresAt === undefined ? {} : { sessionExpiresAt }),
         cursorOrdinal: Math.max(0, Math.floor(ordinal)),
         cursorUpdatedAt: updatedAt,
       }));

--- a/packages/compute-worker/src/playback/storage.ts
+++ b/packages/compute-worker/src/playback/storage.ts
@@ -80,7 +80,7 @@ export interface TtsPlaybackResetScope {
 
 export interface TtsPlaybackSessionStore {
   getSession(sessionId: string): Promise<TtsPlaybackSessionState | null>;
-  putSession(state: TtsPlaybackSessionState): Promise<void>;
+  putSessionIfNewer(state: TtsPlaybackSessionState): Promise<boolean>;
   patchSession(sessionId: string, patch: Partial<Omit<TtsPlaybackSessionState, 'schemaVersion' | 'sessionId'>>): Promise<void>;
   patchSessionIfGenerationRun(
     sessionId: string,
@@ -269,9 +269,38 @@ export function createTtsPlaybackKvStore(input: {
       return session;
     },
 
-    async putSession(state) {
+    async putSessionIfNewer(state) {
       const kv = await input.getKv();
-      await kv.put(sessionKvKey(state.sessionId), sessionCodec.encode(state));
+      const key = sessionKvKey(state.sessionId);
+      let accepted = false;
+      // The canonical session id is reused across starts. The Next control
+      // plane assigns later starts a later expiry, giving overlapping requests
+      // a stable ordering that does not depend on worker arrival order.
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        const entry = await kv.get(key);
+        if (isKvPut(entry)) {
+          const current = sessionCodec.decode(entry.value);
+          if (state.expiresAt <= current.expiresAt) {
+            return (state.generationRunId ?? null) === (current.generationRunId ?? null);
+          }
+          try {
+            await kv.update(key, sessionCodec.encode(state), entry.revision);
+            accepted = true;
+            break;
+          } catch (error) {
+            if (!isKvCasConflictError(error)) throw error;
+            continue;
+          }
+        }
+        try {
+          await kv.create(key, sessionCodec.encode(state));
+          accepted = true;
+          break;
+        } catch (error) {
+          if (!isKvCasConflictError(error)) throw error;
+        }
+      }
+      if (!accepted) throw new Error(`Unable to create playback session ${state.sessionId} after repeated conflicts`);
       await kv.put(cursorKvKey(state.sessionId), cursorCodec.encode({
         cursorOrdinal: Math.max(0, Math.floor(state.cursorOrdinal)),
         cursorUpdatedAt: state.cursorUpdatedAt,
@@ -280,6 +309,7 @@ export function createTtsPlaybackKvStore(input: {
         playbackActive: state.playbackActive !== false,
         updatedAt: state.updatedAt,
       }));
+      return true;
     },
 
     async patchSession(sessionId, patch) {

--- a/packages/compute-worker/tests/unit/model-download-progress.test.ts
+++ b/packages/compute-worker/tests/unit/model-download-progress.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  createModelDownloadProgressReporter,
+  MODEL_DOWNLOAD_PROGRESS_MIN_BYTES,
+} from '../../src/jobs/model-download-progress';
+import type { ModelDownloadProgress } from '../../src/inference/model-download';
+
+describe('model download progress reporting', () => {
+  test('publishes bounded checkpoints without hiding the first or terminal state', async () => {
+    let now = 10_000;
+    const publish = vi.fn(async (progress: ModelDownloadProgress) => {
+      void progress;
+    });
+    const onObserved = vi.fn();
+    const report = createModelDownloadProgressReporter({
+      publish,
+      onObserved,
+      now: () => now,
+    });
+    const totalBytes = MODEL_DOWNLOAD_PROGRESS_MIN_BYTES * 4;
+
+    await report({ downloadedBytes: 0, totalBytes });
+    await report({ downloadedBytes: 1024, totalBytes });
+    await report({ downloadedBytes: MODEL_DOWNLOAD_PROGRESS_MIN_BYTES, totalBytes });
+    now += 1_000;
+    await report({ downloadedBytes: MODEL_DOWNLOAD_PROGRESS_MIN_BYTES + 1024, totalBytes });
+    await report({ downloadedBytes: totalBytes, totalBytes });
+
+    expect(onObserved).toHaveBeenCalledTimes(5);
+    expect(publish.mock.calls.map(([progress]) => progress.downloadedBytes)).toEqual([
+      0,
+      MODEL_DOWNLOAD_PROGRESS_MIN_BYTES,
+      MODEL_DOWNLOAD_PROGRESS_MIN_BYTES + 1024,
+      totalBytes,
+    ]);
+  });
+
+  test('does not treat every chunk as terminal when total size is unknown', async () => {
+    const publish = vi.fn(async (progress: ModelDownloadProgress) => {
+      void progress;
+    });
+    const report = createModelDownloadProgressReporter({ publish, now: () => 10_000 });
+
+    await report({ downloadedBytes: 0, totalBytes: 0 });
+    await report({ downloadedBytes: 1024, totalBytes: 0 });
+    await report({ downloadedBytes: MODEL_DOWNLOAD_PROGRESS_MIN_BYTES, totalBytes: 0 });
+
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/compute-worker/tests/unit/playback-audio-first.test.ts
+++ b/packages/compute-worker/tests/unit/playback-audio-first.test.ts
@@ -57,6 +57,7 @@ describe('playback audio-first segment generation', () => {
     let sidecar: TtsPlaybackSegmentMetadata | null = null;
     const writes: TtsPlaybackSegmentMetadata[] = [];
     const onSegmentCompleted = vi.fn(async () => undefined);
+    const onSynthesisSettled = vi.fn(async () => undefined);
     const playbackStorage = {
       artifacts: {
         readSegmentMetadata: vi.fn(async () => sidecar),
@@ -103,6 +104,7 @@ describe('playback audio-first segment generation', () => {
       audioObjectExists: vi.fn(async () => false),
       playbackStorage,
       synthesisTimeoutMs: 30_000,
+      onSynthesisSettled,
       onSegmentCompleted,
     }).finally(() => {
       finished = true;
@@ -114,6 +116,7 @@ describe('playback audio-first segment generation', () => {
       expect(sidecar?.alignment).toBeNull();
     });
     expect(finished).toBe(false);
+    expect(onSynthesisSettled).toHaveBeenCalledTimes(1);
 
     resolveAlignment({
       alignments: [{

--- a/packages/compute-worker/tests/unit/playback-session-controller.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-controller.test.ts
@@ -38,7 +38,10 @@ function playbackSession(overrides: Partial<PlaybackSessionRow> = {}): PlaybackS
   };
 }
 
-function createFixture(initial: PlaybackSessionRow) {
+function createFixture(
+  initial: PlaybackSessionRow,
+  workerOpStatus: 'queued' | 'running' | 'succeeded' | 'failed' = 'succeeded',
+) {
   let session = initial;
   const enqueueOrReuse = vi.fn(async (request: { opKey: string }) => ({
     opId: 'continuation-op',
@@ -78,7 +81,7 @@ function createFixture(initial: PlaybackSessionRow) {
     deps: { orchestrator: { enqueueOrReuse } },
     playbackStorage,
     ensureOrphanedOpRecovery: vi.fn(async () => undefined),
-    getOpState: vi.fn(async () => ({ status: 'succeeded' as const })),
+    getOpState: vi.fn(async () => ({ status: workerOpStatus })),
   } as unknown as ComputeWorkerRouteContext;
   return {
     controller: createPlaybackSessionController(context, readModel),
@@ -148,8 +151,41 @@ describe('playback session continuation controller', () => {
 
     await fixture.controller.enqueueContinuationIfNeeded({
       ...satisfied,
-      cursorOrdinal: 17,
+      cursorOrdinal: 15,
     }, Date.now(), 'cursor');
     expect(fixture.enqueueOrReuse).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not supersede active synthesis before it publishes a satisfied window', async () => {
+    const fixture = createFixture(playbackSession(), 'running');
+
+    await fixture.controller.enqueueContinuationIfNeeded(
+      fixture.currentSession(),
+      Date.now(),
+      'cursor',
+    );
+
+    expect(fixture.enqueueOrReuse).not.toHaveBeenCalled();
+  });
+
+  test('refills audio while the active predecessor drains exact alignment', async () => {
+    const fixture = createFixture(playbackSession({
+      cursorOrdinal: 15,
+      generationSatisfiedFromOrdinal: 12,
+      generationSatisfiedThroughOrdinal: 20,
+    }), 'running');
+
+    await fixture.controller.enqueueContinuationIfNeeded(
+      fixture.currentSession(),
+      Date.now(),
+      'cursor',
+    );
+
+    expect(fixture.enqueueOrReuse).toHaveBeenCalledTimes(1);
+    expect(fixture.currentSession()).toMatchObject({
+      generationRunId: 'active:15',
+      generationSatisfiedFromOrdinal: null,
+      generationSatisfiedThroughOrdinal: null,
+    });
   });
 });

--- a/packages/compute-worker/tests/unit/playback-session-controller.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-controller.test.ts
@@ -56,11 +56,21 @@ function createFixture(
   const patchSession = vi.fn(async (_sessionId: string, patch: Partial<PlaybackSessionRow>) => {
     session = { ...session, ...patch };
   });
+  const patchSessionIfGenerationRun = vi.fn(async (
+    _sessionId: string,
+    expectedGenerationRunId: string | null,
+    patch: Partial<PlaybackSessionRow>,
+  ) => {
+    if ((session.generationRunId ?? null) !== expectedGenerationRunId) return false;
+    session = { ...session, ...patch };
+    return true;
+  });
   const playbackStorage = {
     sessions: {
       async getSession() { return session; },
       async putSession(next: PlaybackSessionRow) { session = next; },
       patchSession,
+      patchSessionIfGenerationRun,
       updateCursor,
       async listSessions() { return [session]; },
       async cancelSessionsForScope() { return 0; },
@@ -137,6 +147,22 @@ describe('playback session continuation controller', () => {
       playbackActive: true,
       generationRunId: 'active:12',
     });
+  });
+
+  test('does not let a stale continuation supersede a newer generation claim', async () => {
+    const fixture = createFixture(playbackSession({
+      cursorOrdinal: 20,
+      generationRunId: 'active:20',
+    }));
+
+    await fixture.controller.enqueueContinuationIfNeeded(
+      playbackSession({ cursorOrdinal: 12, generationRunId: 'initial:12' }),
+      Date.now(),
+      'cursor',
+    );
+
+    expect(fixture.enqueueOrReuse).not.toHaveBeenCalled();
+    expect(fixture.currentSession().generationRunId).toBe('active:20');
   });
 
   test('refills only after playback crosses the satisfied-window low-water mark', async () => {

--- a/packages/compute-worker/tests/unit/playback-session-controller.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-controller.test.ts
@@ -68,7 +68,13 @@ function createFixture(
   const playbackStorage = {
     sessions: {
       async getSession() { return session; },
-      async putSession(next: PlaybackSessionRow) { session = next; },
+      async putSessionIfNewer(next: PlaybackSessionRow) {
+        if (next.expiresAt <= session.expiresAt) {
+          return (next.generationRunId ?? null) === (session.generationRunId ?? null);
+        }
+        session = next;
+        return true;
+      },
       patchSession,
       patchSessionIfGenerationRun,
       updateCursor,

--- a/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
@@ -87,7 +87,7 @@ function createFixture() {
   const playbackStorage = {
     sessions: {
       async getSession(sessionId: string) { return sessionId === session.sessionId ? session : null; },
-      async putSession() {},
+      async putSessionIfNewer() { return true; },
       async patchSession() {},
       async patchSessionIfGenerationRun() { return true; },
       async updateCursor() {},

--- a/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
@@ -89,6 +89,7 @@ function createFixture() {
       async getSession(sessionId: string) { return sessionId === session.sessionId ? session : null; },
       async putSession() {},
       async patchSession() {},
+      async patchSessionIfGenerationRun() { return true; },
       async updateCursor() {},
       async listSessions() { return []; },
       async cancelSessionsForScope() { return 0; },

--- a/packages/compute-worker/tests/unit/playback-storage.test.ts
+++ b/packages/compute-worker/tests/unit/playback-storage.test.ts
@@ -81,7 +81,7 @@ describe('TTS playback storage', () => {
     const kv = new MemoryKv();
     const store = createTtsPlaybackKvStore({ getKv: async () => kv });
 
-    await store.putSession({
+    await store.putSessionIfNewer({
       schemaVersion: 1,
       sessionId: 'session-1',
       userId: 'user-1',
@@ -149,7 +149,7 @@ describe('TTS playback storage', () => {
     const kv = new NoCasKv();
     const store = createTtsPlaybackKvStore({ getKv: async () => kv });
 
-    await store.putSession({
+    await store.putSessionIfNewer({
       schemaVersion: 1,
       sessionId: 'session-1',
       userId: 'user-1',
@@ -196,7 +196,7 @@ describe('TTS playback storage', () => {
 
     const kv = new InterleavingKv();
     const store = createTtsPlaybackKvStore({ getKv: async () => kv });
-    await store.putSession({
+    await store.putSessionIfNewer({
       schemaVersion: 1,
       sessionId: 'session-1',
       userId: 'user-1',
@@ -237,6 +237,56 @@ describe('TTS playback storage', () => {
     });
   });
 
+  test('does not let an older session request overwrite a newer overlapping request', async () => {
+    class InterleavingKv extends MemoryKv {
+      beforeNextUpdate: (() => Promise<void>) | null = null;
+
+      async update(key: string, data: Uint8Array, version: number): Promise<unknown> {
+        const beforeUpdate = this.beforeNextUpdate;
+        this.beforeNextUpdate = null;
+        if (beforeUpdate) await beforeUpdate();
+        return super.update(key, data, version);
+      }
+    }
+
+    const kv = new InterleavingKv();
+    const store = createTtsPlaybackKvStore({ getKv: async () => kv });
+    const session = (generationRunId: string, expiresAt: number): Parameters<
+      typeof store.putSessionIfNewer
+    >[0] => ({
+      schemaVersion: 1,
+      sessionId: 'session-1',
+      userId: 'user-1',
+      storageUserId: 'storage-1',
+      documentId: 'a'.repeat(64),
+      documentVersion: 1,
+      readerType: 'epub',
+      status: 'queued',
+      settingsHash: 'settings-hash',
+      settingsJson: { voice: 'v' },
+      playbackActive: true,
+      generationRunId,
+      generationStartOrdinal: 10,
+      cursorOrdinal: 10,
+      cursorUpdatedAt: 100,
+      planObjectKey: 'plans/session-1.json',
+      expiresAt,
+      lastError: null,
+      updatedAt: 100,
+    });
+
+    await store.putSessionIfNewer(session('run-original', 100));
+    kv.beforeNextUpdate = async () => {
+      expect(await store.putSessionIfNewer(session('run-newest', 300))).toBe(true);
+    };
+
+    expect(await store.putSessionIfNewer(session('run-middle', 200))).toBe(false);
+    expect(await store.getSession('session-1')).toMatchObject({
+      generationRunId: 'run-newest',
+      expiresAt: 300,
+    });
+  });
+
   test('cancels active sessions matching a playback artifact scope', async () => {
     const kv = new MemoryKv();
     const store = createTtsPlaybackKvStore({ getKv: async () => kv });
@@ -258,11 +308,11 @@ describe('TTS playback storage', () => {
       updatedAt: 100,
     };
 
-    await store.putSession({ ...base, sessionId: 'queued', status: 'queued' });
-    await store.putSession({ ...base, sessionId: 'running', status: 'running' });
-    await store.putSession({ ...base, sessionId: 'succeeded', status: 'succeeded' });
-    await store.putSession({ ...base, sessionId: 'failed', status: 'failed' });
-    await store.putSession({
+    await store.putSessionIfNewer({ ...base, sessionId: 'queued', status: 'queued' });
+    await store.putSessionIfNewer({ ...base, sessionId: 'running', status: 'running' });
+    await store.putSessionIfNewer({ ...base, sessionId: 'succeeded', status: 'succeeded' });
+    await store.putSessionIfNewer({ ...base, sessionId: 'failed', status: 'failed' });
+    await store.putSessionIfNewer({
       ...base,
       sessionId: 'other-settings',
       status: 'running',

--- a/packages/compute-worker/tests/unit/playback-storage.test.ts
+++ b/packages/compute-worker/tests/unit/playback-storage.test.ts
@@ -138,9 +138,9 @@ describe('TTS playback storage', () => {
     });
   });
 
-  test('cursor updates never use CAS (no wrong-last-sequence under contention)', async () => {
-    // A KV that rejects every CAS write — proving the cursor/session paths use
-    // plain puts only. If any of them reach for kv.update, this throws.
+  test('hot cursor and activity updates never use CAS', async () => {
+    // A KV that rejects every CAS write proves the hot client-owned paths stay
+    // plain puts. Worker-owned session record patches intentionally use CAS.
     class NoCasKv extends MemoryKv {
       async update(): Promise<unknown> {
         throw new Error('wrong last sequence');
@@ -169,16 +169,72 @@ describe('TTS playback storage', () => {
       updatedAt: 100,
     });
 
-    // Many racing cursor writers + a concurrent status patch — all plain puts.
+    // Many racing cursor writers plus an activity update are all plain puts.
     await Promise.all([
       ...Array.from({ length: 25 }, (_, i) => store.updateCursor('session-1', i, 1000 + i)),
-      store.patchSession('session-1', { status: 'running', updatedAt: 1100 }),
+      store.patchSession('session-1', { playbackActive: false, updatedAt: 1100 }),
       store.patchSession('session-1', { cursorOrdinal: 5, cursorUpdatedAt: 1200, updatedAt: 1200 }),
     ]);
 
     const session = await store.getSession('session-1');
-    expect(session?.status).toBe('running');
+    expect(session?.status).toBe('queued');
+    expect(session?.playbackActive).toBe(false);
     expect(session?.cursorOrdinal).toBeGreaterThanOrEqual(0);
+  });
+
+  test('rejects a predecessor patch when a successor claims the generation run mid-write', async () => {
+    class InterleavingKv extends MemoryKv {
+      beforeNextUpdate: (() => Promise<void>) | null = null;
+
+      async update(key: string, data: Uint8Array, version: number): Promise<unknown> {
+        const beforeUpdate = this.beforeNextUpdate;
+        this.beforeNextUpdate = null;
+        if (beforeUpdate) await beforeUpdate();
+        return super.update(key, data, version);
+      }
+    }
+
+    const kv = new InterleavingKv();
+    const store = createTtsPlaybackKvStore({ getKv: async () => kv });
+    await store.putSession({
+      schemaVersion: 1,
+      sessionId: 'session-1',
+      userId: 'user-1',
+      storageUserId: 'storage-1',
+      documentId: 'a'.repeat(64),
+      documentVersion: 1,
+      readerType: 'epub',
+      status: 'running',
+      settingsHash: 'settings-hash',
+      settingsJson: { voice: 'v' },
+      playbackActive: true,
+      generationRunId: 'run-old',
+      generationStartOrdinal: 10,
+      cursorOrdinal: 10,
+      cursorUpdatedAt: 100,
+      planObjectKey: 'plans/session-1.json',
+      expiresAt: 1234,
+      lastError: null,
+      updatedAt: 100,
+    });
+
+    kv.beforeNextUpdate = async () => {
+      expect(await store.patchSessionIfGenerationRun('session-1', 'run-old', {
+        generationRunId: 'run-new',
+        generationSatisfiedFromOrdinal: null,
+        generationSatisfiedThroughOrdinal: null,
+      })).toBe(true);
+    };
+
+    expect(await store.patchSessionIfGenerationRun('session-1', 'run-old', {
+      generationSatisfiedFromOrdinal: 10,
+      generationSatisfiedThroughOrdinal: 22,
+    })).toBe(false);
+    expect(await store.getSession('session-1')).toMatchObject({
+      generationRunId: 'run-new',
+      generationSatisfiedFromOrdinal: null,
+      generationSatisfiedThroughOrdinal: null,
+    });
   });
 
   test('cancels active sessions matching a playback artifact scope', async () => {

--- a/packages/compute-worker/tests/unit/playback-storage.test.ts
+++ b/packages/compute-worker/tests/unit/playback-storage.test.ts
@@ -287,6 +287,62 @@ describe('TTS playback storage', () => {
     });
   });
 
+  test('ignores late cursor and activity sidecars from a superseded session write', async () => {
+    class InterleavingKv extends MemoryKv {
+      afterNextUpdate: (() => Promise<void>) | null = null;
+
+      async update(key: string, data: Uint8Array, version: number): Promise<unknown> {
+        const result = await super.update(key, data, version);
+        const afterUpdate = this.afterNextUpdate;
+        this.afterNextUpdate = null;
+        if (afterUpdate) await afterUpdate();
+        return result;
+      }
+    }
+
+    const kv = new InterleavingKv();
+    const store = createTtsPlaybackKvStore({ getKv: async () => kv });
+    const session = (
+      generationRunId: string,
+      expiresAt: number,
+      cursorOrdinal: number,
+      playbackActive: boolean,
+    ): Parameters<typeof store.putSessionIfNewer>[0] => ({
+      schemaVersion: 1,
+      sessionId: 'session-1',
+      userId: 'user-1',
+      storageUserId: 'storage-1',
+      documentId: 'a'.repeat(64),
+      documentVersion: 1,
+      readerType: 'epub',
+      status: 'queued',
+      settingsHash: 'settings-hash',
+      settingsJson: { voice: 'v' },
+      playbackActive,
+      generationRunId,
+      generationStartOrdinal: cursorOrdinal,
+      cursorOrdinal,
+      cursorUpdatedAt: expiresAt,
+      planObjectKey: 'plans/session-1.json',
+      expiresAt,
+      lastError: null,
+      updatedAt: expiresAt,
+    });
+
+    await store.putSessionIfNewer(session('run-original', 100, 10, true));
+    kv.afterNextUpdate = async () => {
+      expect(await store.putSessionIfNewer(session('run-newest', 300, 30, true))).toBe(true);
+    };
+
+    expect(await store.putSessionIfNewer(session('run-middle', 200, 20, false))).toBe(true);
+    expect(await store.getSession('session-1')).toMatchObject({
+      generationRunId: 'run-newest',
+      expiresAt: 300,
+      cursorOrdinal: 30,
+      playbackActive: true,
+    });
+  });
+
   test('cancels active sessions matching a playback artifact scope', async () => {
     const kv = new MemoryKv();
     const store = createTtsPlaybackKvStore({ getKv: async () => kv });

--- a/src/hooks/audio/usePlaybackForegroundSync.ts
+++ b/src/hooks/audio/usePlaybackForegroundSync.ts
@@ -76,18 +76,26 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
     playbackEventsUnsubRef.current = subscribeTtsPlaybackEvents(activeSession.sessionId, {
       onSnapshot: (snapshot) => {
         if (runId !== playbackRunIdRef.current) return;
+        if (snapshot.status === 'failed') {
+          toast.dismiss(MODEL_DOWNLOAD_TOAST_ID);
+          return;
+        }
         if (snapshot.phase === 'downloading_model') {
           const percent = snapshot.totalBytes && snapshot.downloadedBytes !== null
             ? Math.round((snapshot.downloadedBytes / snapshot.totalBytes) * 100)
             : null;
           toast.loading(
-            percent === null ? 'Downloading playback model…' : `Downloading playback model… ${percent}%`,
+            percent === null
+              ? 'Downloading word-timing model…'
+              : `Downloading word-timing model… ${percent}%`,
             { id: MODEL_DOWNLOAD_TOAST_ID },
           );
-        } else {
-          toast.dismiss(MODEL_DOWNLOAD_TOAST_ID);
+          // Audio is already available with proportional timing. Download-only
+          // progress does not change either playback read model, so avoid two
+          // redundant HTTP reads for every model checkpoint.
+          return;
         }
-        if (snapshot.status === 'failed') return;
+        toast.dismiss(MODEL_DOWNLOAD_TOAST_ID);
         const currentSession = playbackSessionRef.current;
         if (!currentSession) return;
         void refreshPlaybackTimeline(currentSession.timelineUrl).catch(() => undefined);

--- a/src/types/tts.ts
+++ b/src/types/tts.ts
@@ -13,7 +13,7 @@ export type {
  * client heartbeats its cursor, so generation tracks the listener instead of
  * racing to the end of the document.
  */
-export const TTS_PLAYBACK_AHEAD_WINDOW = 8;
+export const TTS_PLAYBACK_AHEAD_WINDOW = 12;
 
 /**
  * How often the client POSTs its playback cursor while playing. Must be well

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -1597,7 +1597,8 @@ worker logs showed one initial playback job, no prefetch-driven
 
 ### 26. Harden Live Playback for Production Latency and Cold Model Load
 
-Status: in progress. The first deployed v5 stack exposed latency assumptions
+Status: implementation complete; deployed cold-model validation pending. The
+first deployed v5 stack exposed latency assumptions
 that the local same-host acceptance runs did not exercise:
 
 - The live generation window was only eight segments and waited until half of
@@ -1627,6 +1628,7 @@ that the local same-host acceptance runs did not exercise:
 
 Local verification passed the worker unit suite, root Vitest suite, application
 and worker type checks, changed-source lint, production build, compute boundary,
-route-error, and server-bundle guards. A subsequent deployed cold-model
+route-error, and server-bundle guards, plus the complete 24-case Chromium/WebKit
+Playwright matrix with both real playback journeys. A subsequent deployed cold-model
 walkthrough should confirm bounded model progress, uninterrupted audio refill,
 and exact timing replacement after the model becomes ready.

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -1592,3 +1592,41 @@ long EPUB at Chapter Twenty-Three, retained the document-wide cached timeline,
 started playback at its canonical document time, and paused cleanly. Final
 worker logs showed one initial playback job, no prefetch-driven
 `tts.playback.resume_enqueued` cascade, and a clean audio client close on pause.
+
+---
+
+### 26. Harden Live Playback for Production Latency and Cold Model Load
+
+Status: in progress. The first deployed v5 stack exposed latency assumptions
+that the local same-host acceptance runs did not exercise:
+
+- The live generation window was only eight segments and waited until half of
+  that window remained before asking for a continuation. The active window is
+  now twelve segments and refills while roughly three quarters remain, giving
+  the provider, NATS, object storage, and browser heartbeat more recovery time
+  without returning to per-segment enqueueing.
+- A bounded playback job kept its operation nonterminal while its ordered
+  best-effort Whisper lane drained. The job now publishes its satisfied audio
+  boundary as soon as synthesis settles. Once playback crosses the low-water
+  mark, the controller may supersede that alignment-draining run with the next
+  deterministic audio continuation. The process still admits only one Whisper
+  inference at a time, preventing superseded runs from multiplying CPU and
+  memory pressure.
+- Cold Whisper download progress previously produced a durable operation update
+  about once per MiB. For the 268 MB model this could create hundreds of NATS
+  writes and, through foreground SSE handling, two browser read-model requests
+  per update. Model downloads now publish at bounded eight-MiB/one-second
+  checkpoints, and download-only snapshots update only the word-timing toast.
+  Timeline and seek-layout reads remain driven by segment/audio or exact-timing
+  changes.
+- The playback toast now calls this the `word-timing model`. Audio continues to
+  use proportional timing while the cold model downloads; visible highlighting
+  during that download is therefore not evidence that exact Whisper alignment
+  has already completed. Whisper artifact acquisition remains single-flight per
+  worker process.
+
+Local verification passed the worker unit suite, root Vitest suite, application
+and worker type checks, changed-source lint, production build, compute boundary,
+route-error, and server-bundle guards. A subsequent deployed cold-model
+walkthrough should confirm bounded model progress, uninterrupted audio refill,
+and exact timing replacement after the model becomes ready.

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -10,15 +10,16 @@ hard cut, and the final Next/worker ownership model.
 
 ## Core Rules
 
-Classify playback state by `durability x write-frequency`, and do not use CAS in
-the playback path.
+Classify playback state by `durability x write-frequency`. Reserve CAS for the
+low-frequency worker-owned session record and operation state; hot client state
+must remain contention-free.
 
 | State | Home | Write model |
 |---|---|---|
 | Playback plan | S3, immutable plan object | write once |
 | Segment audio | S3, content-addressed CBR MP3 under `tts_playback_segments_audio_v1/` | idempotent put |
 | Segment duration/alignment/status | S3, one sidecar per plan ordinal | put to unique key |
-| Session record | JetStream KV, `tts_playback.session.*` | plain `put` |
+| Session record | JetStream KV, `tts_playback.session.*` | retrying CAS for patches and generation ownership |
 | Cursor/playhead | JetStream KV, `tts_playback.cursor.*` | plain `put`, last-write-wins |
 | Job queue | JetStream stream, `compute_jobs` subjects | small durable work messages |
 | Operation index/state | JetStream KV, `op_index.*` / `op_state.*` | CAS only for op claiming/state machine |
@@ -28,7 +29,8 @@ the playback path.
 The important invariant is that hot cursor updates never rewrite the worker-owned
 session record. Cursor writes happen on their own KV key, so a per-second browser
 heartbeat, audio-range re-anchor, and worker status update cannot collide on one
-revision. `kv.update(...revision)` should not appear in playback storage.
+revision. Session patches use bounded retrying CAS so a superseded generation
+run cannot overwrite its successor after an ownership check.
 
 Classify API ownership by `request duration x compute/memory/streaming cost`.
 Next.js routes run under Vercel's request-duration model and should own
@@ -376,7 +378,7 @@ For EPUB specifically, the client owns only reader rendering/navigation concerns
 
 ## Invariants
 
-- No CAS (`kv.update`) in playback storage.
+- CAS is limited to low-frequency session-record patches and generation ownership.
 - Cursor state lives on its own KV key and is overlaid onto sessions on read.
 - Cursor writes are plain `put`, last-write-wins.
 - Session record patches must not rewrite cursor-only updates into the session

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -20,7 +20,7 @@ must remain contention-free.
 | Segment audio | S3, content-addressed CBR MP3 under `tts_playback_segments_audio_v1/` | idempotent put |
 | Segment duration/alignment/status | S3, one sidecar per plan ordinal | put to unique key |
 | Session record | JetStream KV, `tts_playback.session.*` | retrying CAS for patches and generation ownership |
-| Cursor/playhead | JetStream KV, `tts_playback.cursor.*` | plain `put`, last-write-wins |
+| Cursor/playhead | JetStream KV, `tts_playback.cursor.*` | expiry-tagged plain `put`, last-write-wins within one session generation |
 | Job queue | JetStream stream, `compute_jobs` subjects | small durable work messages |
 | Operation index/state | JetStream KV, `op_index.*` / `op_state.*` | CAS only for op claiming/state machine |
 | SSE events | JetStream stream, `compute_events` subjects | replayable operation snapshots |
@@ -33,6 +33,8 @@ revision. Session patches use bounded retrying CAS so a superseded generation
 run cannot overwrite its successor after an ownership check. Initial requests
 for a reused canonical session are also installed conditionally, ordered by the
 control plane's session expiry, so delayed requests cannot restore an older run.
+Cursor and activity sidecars carry that same expiry; reads ignore a late sidecar
+write when its session generation no longer matches the canonical record.
 
 Classify API ownership by `request duration x compute/memory/streaming cost`.
 Next.js routes run under Vercel's request-duration model and should own

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -30,7 +30,9 @@ The important invariant is that hot cursor updates never rewrite the worker-owne
 session record. Cursor writes happen on their own KV key, so a per-second browser
 heartbeat, audio-range re-anchor, and worker status update cannot collide on one
 revision. Session patches use bounded retrying CAS so a superseded generation
-run cannot overwrite its successor after an ownership check.
+run cannot overwrite its successor after an ownership check. Initial requests
+for a reused canonical session are also installed conditionally, ordered by the
+control plane's session expiry, so delayed requests cannot restore an older run.
 
 Classify API ownership by `request duration x compute/memory/streaming cost`.
 Next.js routes run under Vercel's request-duration model and should own


### PR DESCRIPTION
## Summary

- expand the bounded live-audio runway from 8 to 12 segments and refill it earlier
- allow deterministic audio continuation once the preceding run has finished synthesis but is still draining best-effort Whisper alignment
- serialize Whisper inference process-wide and skip superseded queued alignment work
- reduce cold-model progress writes and stop download-only SSE snapshots from refetching playback layouts
- clarify that cold playback downloads are for word timing, while proportional highlighting remains available

## Why

The deployed v5 topology adds real provider, NATS, object-storage, Vercel, and browser latency. The previous half-window refill could run out of audio, especially because a completed synthesis window remained blocked behind its alignment lane. A cold 268 MB model download also generated roughly one durable progress update per MiB, with two redundant browser reads per update.

## Verification

- `pnpm test` (128 files, 631 tests)
- `pnpm test:compute` (34 files, 142 tests)
- `pnpm exec tsc --noEmit`
- changed-source ESLint
- `pnpm build`
- compute-boundary, route-error, and server-bundle guards

The existing `openreader-v5-upgrade-check` Compose project was left untouched; no duplicate local stack or Playwright server was started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Playback now prepares more upcoming segments and refills sooner, helping reduce interruptions.
  - Word-timing model downloads report progress at clear, bounded intervals.

- **Bug Fixes**
  - Improved handling of overlapping, stale, and superseded playback updates.
  - Prevented outdated session information from overwriting newer playback state.
  - Download-only updates no longer trigger unnecessary timeline refreshes.
  - Failed playback updates dismiss download notifications promptly.
  - Updated notification text to “Downloading word-timing model…”.
  - Playback alignment no longer runs concurrently for overlapping requests.

- **Documentation**
  - Added guidance for session-safe playback state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->