### PR TITLE
Fix leaked worker HTTP activity

### DIFF
--- a/packages/compute-worker/src/api/http-hooks.ts
+++ b/packages/compute-worker/src/api/http-hooks.ts
@@ -60,6 +60,9 @@ export function registerHttpHooks(input: {
     (request as FastifyRequest & { [REQUEST_COUNTED_KEY]?: boolean })[REQUEST_COUNTED_KEY] = true;
     input.onInFlightHttpChanged(1);
     input.markActivity(`http_started:${path}`);
+    reply.raw.once('close', () => {
+      releaseHttp(request);
+    });
     if (!isHealthPath(path) && !isPublicPlaybackPath(path) && !isAuthed(request, input.workerToken)) {
       return reply.code(401).send({ error: 'Unauthorized' });
     }

--- a/packages/compute-worker/tests/unit/http-hooks.test.ts
+++ b/packages/compute-worker/tests/unit/http-hooks.test.ts
@@ -1,0 +1,72 @@
+import { EventEmitter } from 'node:events';
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { describe, expect, test, vi } from 'vitest';
+
+import { registerHttpHooks } from '../../src/api/http-hooks';
+
+type HttpHook = (request: FastifyRequest, reply: FastifyReply) => Promise<unknown>;
+
+function createHarness() {
+  const hooks = new Map<string, HttpHook>();
+  const markActivity = vi.fn();
+  const onInFlightHttpChanged = vi.fn();
+  const app = {
+    addHook: (name: string, hook: HttpHook) => {
+      hooks.set(name, hook);
+    },
+    log: { error: vi.fn() },
+  } as unknown as FastifyInstance;
+
+  registerHttpHooks({
+    app,
+    workerToken: 'test-token',
+    markActivity,
+    onInFlightHttpChanged,
+  });
+
+  const response = new EventEmitter();
+  const request = {
+    headers: { authorization: 'Bearer test-token' },
+    id: 'request-1',
+    method: 'GET',
+    params: {},
+    url: '/v1/operations/op-1',
+  } as unknown as FastifyRequest;
+  const reply = {
+    raw: response,
+    statusCode: 200,
+  } as unknown as FastifyReply;
+
+  return {
+    hooks,
+    markActivity,
+    onInFlightHttpChanged,
+    reply,
+    request,
+    response,
+  };
+}
+
+describe('compute worker HTTP accounting', () => {
+  test('releases an aborted response when the response socket closes', async () => {
+    const harness = createHarness();
+
+    await harness.hooks.get('onRequest')?.(harness.request, harness.reply);
+    harness.response.emit('close');
+
+    expect(harness.onInFlightHttpChanged.mock.calls.map(([delta]) => delta)).toEqual([1, -1]);
+    expect(harness.markActivity).toHaveBeenLastCalledWith('http_completed');
+  });
+
+  test('counts a normally completed response only once', async () => {
+    const harness = createHarness();
+
+    await harness.hooks.get('onRequest')?.(harness.request, harness.reply);
+    await harness.hooks.get('onResponse')?.(harness.request, harness.reply);
+    harness.response.emit('close');
+
+    expect(harness.onInFlightHttpChanged.mock.calls.map(([delta]) => delta)).toEqual([1, -1]);
+    expect(harness.markActivity.mock.calls.filter(([reason]) => reason === 'http_completed')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- release in-flight HTTP accounting when a response socket closes early
- preserve normal completion and SSE behavior with idempotent release handling
- cover aborted and normally completed response lifecycles

## Validation
- pnpm test (638 passed)
- compute worker TypeScript and ESLint checks
- pnpm compute:openapi:check
- pnpm check:compute-boundary
- pnpm build
- pnpm build:bundle-guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request tracking so in-flight request counts are released when response connections close.
  * Prevented completed requests from being counted more than once.

* **Tests**
  * Added coverage for request counting during connection closure and normal response completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->