### PR TITLE
fix: preserve live playback state and cancel stale generation

### DIFF
--- a/packages/compute-worker/src/api/playback/session-controller.ts
+++ b/packages/compute-worker/src/api/playback/session-controller.ts
@@ -68,6 +68,11 @@ export function createPlaybackSessionController(
     ) return;
 
     const hasSatisfiedWindow = satisfiedFrom !== null && satisfiedThrough !== null;
+    const generationStartOrdinal = Math.max(
+      0,
+      Math.floor(Number(session.generationStartOrdinal ?? cursorOrdinal)),
+    );
+    const isExplicitReposition = reason === 'stream' && cursorOrdinal !== generationStartOrdinal;
     if (session.workerOpId) {
       const current = await getOpState(session.workerOpId).catch((error) => {
         app.log.warn(
@@ -80,7 +85,12 @@ export function createPlaybackSessionController(
       // a satisfied window, however, it may only be draining best-effort exact
       // alignment. Let low-water refill supersede that run so alignment cannot
       // starve audible audio generation.
-      if (current && !isTerminalStatus(current.status) && !hasSatisfiedWindow) return;
+      if (
+        current
+        && !isTerminalStatus(current.status)
+        && !hasSatisfiedWindow
+        && !isExplicitReposition
+      ) return;
     }
 
     // Cursor heartbeats and audio consumption are two signals for the same

--- a/packages/compute-worker/src/api/playback/session-controller.ts
+++ b/packages/compute-worker/src/api/playback/session-controller.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW,
   generationFloorForCursor,
 } from '../../playback/generation-window';
+import { resolveTtsPlaybackSessionInstanceId } from '../../playback/storage';
 import { ttsPlaybackOperationCreateSchema } from '../schemas';
 import type { ComputeWorkerRouteContext } from '../route-context';
 import { isTerminalStatus, toErrorMessage } from '../route-context';
@@ -171,10 +172,18 @@ export function createPlaybackSessionController(
     enqueueContinuationIfNeeded,
     async updateCursor(sessionId, ordinal, options) {
       const now = Date.now();
-      await playbackStorage?.sessions.updateCursor(sessionId, ordinal, now).catch((error) => {
+      const initialSession = await readModel.readSession(sessionId);
+      if (!initialSession) return;
+      const cursorUpdated = await playbackStorage?.sessions.updateCursor(
+        sessionId,
+        ordinal,
+        resolveTtsPlaybackSessionInstanceId(initialSession),
+        now,
+      ).catch((error) => {
         app.log.warn({ sessionId, error: toErrorMessage(error) }, 'tts.playback.cursor_kv_update_failed');
+        return false;
       });
-      if (!options?.ensureGeneration) return;
+      if (!cursorUpdated || !options?.ensureGeneration) return;
       const session = await readModel.readSession(sessionId);
       // Only a stream that is seeking or blocked on missing audio may force a
       // continuation. Ordinary segment delivery updates the cursor without

--- a/packages/compute-worker/src/infrastructure/nats-adapters.ts
+++ b/packages/compute-worker/src/infrastructure/nats-adapters.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { AckPolicy, DeliverPolicy, ReplayPolicy, type JetStreamClient, type JetStreamManager } from '@nats-io/jetstream';
+import type { KV } from '@nats-io/kv';
 import { nanos } from '@nats-io/transport-node';
 import type {
   OperationEvent,
@@ -34,6 +35,7 @@ export interface KvStoreLike {
   create(key: string, data: Uint8Array): Promise<unknown>;
   update(key: string, data: Uint8Array, version: number): Promise<unknown>;
   keys(filter?: string | string[]): Promise<AsyncIterable<string>>;
+  watch?: KV['watch'];
 }
 
 export function isKvCasConflictError(error: unknown): boolean {

--- a/packages/compute-worker/src/jobs/playback/playback-job.ts
+++ b/packages/compute-worker/src/jobs/playback/playback-job.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW,
   generationFloorForCursor,
 } from '../../playback/generation-window';
+import { resolveTtsPlaybackSessionInstanceId } from '../../playback/storage';
 import type { JobHandlerContext } from '../context';
 import { createModelDownloadProgressReporter } from '../model-download-progress';
 import { resolveAndPersistTtsPlaybackPlan } from './plan';
@@ -235,6 +236,7 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
       try {
         await generateExplicitTtsPlaybackSegments({
           request: parsed,
+          sessionInstanceId: resolveTtsPlaybackSessionInstanceId(currentSession),
           s3Prefix: input.s3Prefix,
           segments: generationSegments,
           putAudioObject: (key, body) => input.storage.putObject(key, body, 'audio/mpeg'),

--- a/packages/compute-worker/src/jobs/playback/playback-job.ts
+++ b/packages/compute-worker/src/jobs/playback/playback-job.ts
@@ -224,36 +224,50 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
       const generationSegments = forceDocumentExtent
         ? plannedSegments
         : plannedSegments.filter((segment) => segment.ordinal >= generationFloor);
-      await generateExplicitTtsPlaybackSegments({
-        request: parsed,
-        s3Prefix: input.s3Prefix,
-        segments: generationSegments,
-        putAudioObject: (key, body) => input.storage.putObject(key, body, 'audio/mpeg'),
-        deleteAudioObject: input.storage.deleteObject,
-        audioObjectExists: input.storage.objectExists,
-        playbackStorage,
-        readAudioObject: async (key) => Buffer.from(await input.storage.readObject(key)),
-        cacheEpoch,
-        getCurrentCacheEpoch: readCurrentCacheEpoch,
-        synthesisTimeoutMs: Math.max(input.ttsPlaybackSegmentTimeoutMs, 1_000),
-        onBeforeSegment,
-        onSynthesisSettled: persistSatisfiedWindowIfCurrent,
-        onSegmentCompleted,
-        onSegmentErrored: async (planOrdinal) => {
-          erroredOrdinals.add(planOrdinal);
-          await emitProgress();
-        },
-        onModelDownloadProgress: createModelDownloadProgressReporter({
-          publish: async ({ downloadedBytes, totalBytes }) => hooks?.onProgress?.({
-            completedThroughOrdinal: lastCompletedThrough,
-            completedCount: completedOrdinals.size,
-            plannedCount: plannedSegments.length,
-            phase: 'downloading_model',
-            downloadedBytes,
-            totalBytes,
+      const generationController = new AbortController();
+      const stopWatchingGeneration = forceDocumentExtent
+        ? () => undefined
+        : await playbackStorage.sessions.watchGenerationInvalidation(
+          parsed.sessionId,
+          generationRunId,
+          () => generationController.abort(new Error('Playback generation was superseded or paused')),
+        ).catch(() => () => undefined);
+      try {
+        await generateExplicitTtsPlaybackSegments({
+          request: parsed,
+          s3Prefix: input.s3Prefix,
+          segments: generationSegments,
+          putAudioObject: (key, body) => input.storage.putObject(key, body, 'audio/mpeg'),
+          deleteAudioObject: input.storage.deleteObject,
+          audioObjectExists: input.storage.objectExists,
+          playbackStorage,
+          readAudioObject: async (key) => Buffer.from(await input.storage.readObject(key)),
+          cacheEpoch,
+          getCurrentCacheEpoch: readCurrentCacheEpoch,
+          synthesisTimeoutMs: Math.max(input.ttsPlaybackSegmentTimeoutMs, 1_000),
+          signal: generationController.signal,
+          onBeforeSegment,
+          onSynthesisSettled: persistSatisfiedWindowIfCurrent,
+          onSegmentCompleted,
+          onSegmentErrored: async (planOrdinal) => {
+            erroredOrdinals.add(planOrdinal);
+            await emitProgress();
+          },
+          onModelDownloadProgress: createModelDownloadProgressReporter({
+            publish: async ({ downloadedBytes, totalBytes }) => hooks?.onProgress?.({
+              completedThroughOrdinal: lastCompletedThrough,
+              completedCount: completedOrdinals.size,
+              plannedCount: plannedSegments.length,
+              phase: 'downloading_model',
+              downloadedBytes,
+              totalBytes,
+            }),
           }),
-        }),
-      });
+        });
+      } finally {
+        stopWatchingGeneration();
+      }
+      if (generationController.signal.aborted) stoppedEarly = true;
       const finalSession = await playbackStorage.sessions.getSession(parsed.sessionId).catch(() => null);
       const cacheEpochStillCurrent = await readCurrentCacheEpoch() === cacheEpoch;
       const generationRunIsCurrent = Boolean(

--- a/packages/compute-worker/src/jobs/playback/segment-generation.ts
+++ b/packages/compute-worker/src/jobs/playback/segment-generation.ts
@@ -96,8 +96,25 @@ export function classifySegmentError(error: unknown): { info: SegmentErrorInfo; 
   return { info: { message, code: 'UPSTREAM_ERROR', upstreamStatus }, retryable: false };
 }
 
+export function leaseBelongsToPlaybackSession(
+  ownerId: string,
+  sessionId: string,
+  sessionInstanceId: string,
+): boolean {
+  try {
+    const parsed = JSON.parse(ownerId) as { sessionId?: unknown; sessionInstanceId?: unknown };
+    return parsed.sessionId === sessionId && parsed.sessionInstanceId === sessionInstanceId;
+  } catch {
+    // Legacy owner ids cannot prove which incarnation wrote them. Treat them
+    // as foreign until their bounded lease expires rather than overlapping
+    // synthesis with a replaced session.
+    return false;
+  }
+}
+
 export async function generateExplicitTtsPlaybackSegments(input: {
   request: TtsPlaybackRequest;
+  sessionInstanceId: string;
   s3Prefix: string;
   segments: TtsPlaybackSegmentInput[];
   putAudioObject: (key: string, body: Buffer) => Promise<void>;
@@ -268,18 +285,10 @@ export async function generateExplicitTtsPlaybackSegments(input: {
 
   const leaseOwnerId = JSON.stringify({
     sessionId: input.request.sessionId,
+    sessionInstanceId: input.sessionInstanceId,
     generationExtent: input.request.generationExtent ?? 'window',
     generationRunId: input.request.generationRunId ?? 'initial',
   });
-  const leaseBelongsToCurrentSession = (ownerId: string): boolean => {
-    try {
-      const parsed = JSON.parse(ownerId) as { sessionId?: unknown };
-      return parsed.sessionId === input.request.sessionId;
-    } catch {
-      // Backward compatibility for leases written before owner ids became JSON.
-      return ownerId.startsWith(`${input.request.sessionId}:`);
-    }
-  };
   const leaseStaleMs = Math.max(GENERATION_LEASE_MIN_MS, input.synthesisTimeoutMs + GENERATION_LEASE_GRACE_MS);
   const minCacheEpoch = Math.max(0, Math.floor(Number(input.cacheEpoch ?? 0)));
   const freshSidecar = async (segment: (typeof normalized)[number]) => {
@@ -293,10 +302,14 @@ export async function generateExplicitTtsPlaybackSegments(input: {
   ): boolean => {
     if (!sidecar || sidecar.status !== 'generating' || sidecar.audioKey !== audioKey) return false;
     if (!sidecar.leaseOwnerId || sidecar.leaseOwnerId === leaseOwnerId) return false;
-    // One canonical live session has exactly one current generation run. Its
-    // successor may immediately steal its predecessor's lease after a seek or
-    // resume; the predecessor checks generation ownership before every write.
-    if (leaseBelongsToCurrentSession(sidecar.leaseOwnerId)) return false;
+    // One canonical session incarnation has exactly one current generation
+    // run. Its successor may immediately steal its predecessor's lease after a
+    // seek or resume; a replacement incarnation must respect the old lease.
+    if (leaseBelongsToPlaybackSession(
+      sidecar.leaseOwnerId,
+      input.request.sessionId,
+      input.sessionInstanceId,
+    )) return false;
     const leaseUpdatedAt = Number(sidecar.leaseUpdatedAt ?? sidecar.updatedAt ?? 0);
     return Number.isFinite(leaseUpdatedAt) && now - leaseUpdatedAt < leaseStaleMs;
   };

--- a/packages/compute-worker/src/jobs/playback/segment-generation.ts
+++ b/packages/compute-worker/src/jobs/playback/segment-generation.ts
@@ -50,8 +50,17 @@ async function withAbortableTimeout<T>(
   run: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number,
   label: string,
+  externalSignal?: AbortSignal,
 ): Promise<T> {
   const controller = new AbortController();
+  const abortFromExternalSignal = () => controller.abort(externalSignal?.reason);
+  if (externalSignal?.aborted) abortFromExternalSignal();
+  else externalSignal?.addEventListener('abort', abortFromExternalSignal, { once: true });
+  if (controller.signal.aborted) {
+    throw controller.signal.reason instanceof Error
+      ? controller.signal.reason
+      : new DOMException('Aborted', 'AbortError');
+  }
   const operation = run(controller.signal);
   try {
     return await withTimeout(operation, timeoutMs, label);
@@ -62,6 +71,7 @@ async function withAbortableTimeout<T>(
     }
     throw error;
   } finally {
+    externalSignal?.removeEventListener('abort', abortFromExternalSignal);
     controller.abort();
   }
 }
@@ -98,16 +108,26 @@ export async function generateExplicitTtsPlaybackSegments(input: {
   cacheEpoch?: number;
   getCurrentCacheEpoch?: () => Promise<number>;
   synthesisTimeoutMs: number;
+  signal?: AbortSignal;
   onBeforeSegment?: (planOrdinal: number) => Promise<'continue' | 'stop'>;
   onSynthesisSettled?: () => Promise<void>;
   onSegmentCompleted?: (planOrdinal: number) => Promise<void>;
   onSegmentErrored?: (planOrdinal: number) => Promise<void>;
   onModelDownloadProgress?: ModelDownloadProgressHandler;
 }): Promise<void> {
-  if (input.segments.length === 0) return;
+  if (input.segments.length === 0 || input.signal?.aborted) return;
 
   const settings = parseTtsSettings(input.request.settingsJson);
-  const requestCreds = await resolveTtsCredentialsFromBroker(settings.providerRef);
+  let requestCreds: Awaited<ReturnType<typeof resolveTtsCredentialsFromBroker>>;
+  try {
+    requestCreds = await resolveTtsCredentialsFromBroker(
+      settings.providerRef,
+      input.signal ? { signal: input.signal } : undefined,
+    );
+  } catch (error) {
+    if (input.signal?.aborted) return;
+    throw error;
+  }
   const effectiveProviderRef = requestCreds.providerRef;
   const resolvedProviderType = requestCreds.providerType;
   const effectiveModel = resolveTtsModelForProvider({
@@ -238,6 +258,7 @@ export async function generateExplicitTtsPlaybackSegments(input: {
   };
 
   const shouldContinueWrites = async (planOrdinal: number): Promise<boolean> => {
+    if (input.signal?.aborted) return false;
     if (input.onBeforeSegment && await input.onBeforeSegment(planOrdinal) === 'stop') return false;
     if (input.cacheEpoch !== undefined && input.getCurrentCacheEpoch) {
       if (await input.getCurrentCacheEpoch() !== input.cacheEpoch) return false;
@@ -245,11 +266,20 @@ export async function generateExplicitTtsPlaybackSegments(input: {
     return true;
   };
 
-  const leaseOwnerId = [
-    input.request.sessionId,
-    input.request.generationExtent ?? 'window',
-    input.request.generationRunId ?? 'initial',
-  ].join(':');
+  const leaseOwnerId = JSON.stringify({
+    sessionId: input.request.sessionId,
+    generationExtent: input.request.generationExtent ?? 'window',
+    generationRunId: input.request.generationRunId ?? 'initial',
+  });
+  const leaseBelongsToCurrentSession = (ownerId: string): boolean => {
+    try {
+      const parsed = JSON.parse(ownerId) as { sessionId?: unknown };
+      return parsed.sessionId === input.request.sessionId;
+    } catch {
+      // Backward compatibility for leases written before owner ids became JSON.
+      return ownerId.startsWith(`${input.request.sessionId}:`);
+    }
+  };
   const leaseStaleMs = Math.max(GENERATION_LEASE_MIN_MS, input.synthesisTimeoutMs + GENERATION_LEASE_GRACE_MS);
   const minCacheEpoch = Math.max(0, Math.floor(Number(input.cacheEpoch ?? 0)));
   const freshSidecar = async (segment: (typeof normalized)[number]) => {
@@ -263,6 +293,10 @@ export async function generateExplicitTtsPlaybackSegments(input: {
   ): boolean => {
     if (!sidecar || sidecar.status !== 'generating' || sidecar.audioKey !== audioKey) return false;
     if (!sidecar.leaseOwnerId || sidecar.leaseOwnerId === leaseOwnerId) return false;
+    // One canonical live session has exactly one current generation run. Its
+    // successor may immediately steal its predecessor's lease after a seek or
+    // resume; the predecessor checks generation ownership before every write.
+    if (leaseBelongsToCurrentSession(sidecar.leaseOwnerId)) return false;
     const leaseUpdatedAt = Number(sidecar.leaseUpdatedAt ?? sidecar.updatedAt ?? 0);
     return Number.isFinite(leaseUpdatedAt) && now - leaseUpdatedAt < leaseStaleMs;
   };
@@ -300,6 +334,7 @@ export async function generateExplicitTtsPlaybackSegments(input: {
 
   segmentLoop:
   for (const segment of normalized) {
+    if (input.signal?.aborted) break;
     const planOrdinal = segment.original.ordinal;
     if (input.onBeforeSegment && await input.onBeforeSegment(planOrdinal) === 'stop') break;
     const audioKey = buildTtsPlaybackSegmentAudioKey({
@@ -406,6 +441,7 @@ export async function generateExplicitTtsPlaybackSegments(input: {
           }, signal, { ttsUpstreamTimeoutMs: input.synthesisTimeoutMs }),
           input.synthesisTimeoutMs,
           'tts playback segment synthesis',
+          input.signal,
         );
         if (!await shouldContinueWrites(planOrdinal)) return;
         await input.putAudioObject(audioKey, audioBuffer);
@@ -430,6 +466,7 @@ export async function generateExplicitTtsPlaybackSegments(input: {
         completed = true;
         break;
       } catch (error) {
+        if (input.signal?.aborted) return;
         lastError = error;
         const classified = classifySegmentError(error);
         lastErrorInfo = classified.info;

--- a/packages/compute-worker/src/playback/storage.ts
+++ b/packages/compute-worker/src/playback/storage.ts
@@ -27,6 +27,8 @@ export interface TtsPlaybackSessionState {
   playbackActive?: boolean;
   /** Identifies the generation run that currently owns this canonical session. */
   generationRunId?: string | null;
+  /** Stable identity for one canonical-session incarnation; unlike expiresAt it never rolls. */
+  sessionInstanceId?: string;
   generationSatisfiedFromOrdinal?: number | null;
   generationSatisfiedThroughOrdinal?: number | null;
   planning?: unknown;
@@ -88,6 +90,11 @@ export interface TtsPlaybackSessionStore {
     patch: Partial<Omit<TtsPlaybackSessionState, 'schemaVersion' | 'sessionId'>>,
   ): Promise<boolean>;
   updateCursor(sessionId: string, ordinal: number, updatedAt?: number): Promise<void>;
+  watchGenerationInvalidation(
+    sessionId: string,
+    expectedGenerationRunId: string | null,
+    onInvalidated: () => void,
+  ): Promise<() => void>;
   listSessions(scope?: TtsPlaybackResetScope): Promise<TtsPlaybackSessionState[]>;
   cancelSessionsForScope(scope: TtsPlaybackResetScope, updatedAt?: number): Promise<number>;
 }
@@ -166,6 +173,7 @@ function isResettableSessionStatus(status: TtsPlaybackSessionStatus): boolean {
 }
 
 interface TtsPlaybackCursorRecord {
+  sessionInstanceId?: string;
   sessionExpiresAt?: number;
   cursorOrdinal: number;
   cursorUpdatedAt: number | null;
@@ -177,13 +185,25 @@ interface TtsPlaybackCacheEpochRecord {
 }
 
 interface TtsPlaybackActivityRecord {
+  sessionInstanceId?: string;
   sessionExpiresAt?: number;
   playbackActive: boolean;
   updatedAt: number;
 }
 
-function sidecarMatchesSession(sidecarExpiresAt: number | undefined, sessionExpiresAt: number): boolean {
-  return sidecarExpiresAt === undefined || sidecarExpiresAt === sessionExpiresAt;
+function resolveSessionInstanceId(session: TtsPlaybackSessionState): string {
+  return session.sessionInstanceId
+    ?? `legacy:${session.expiresAt}:${session.generationRunId ?? 'initial'}`;
+}
+
+function sidecarMatchesSession(
+  sidecar: { sessionInstanceId?: string; sessionExpiresAt?: number },
+  session: TtsPlaybackSessionState,
+): boolean {
+  if (sidecar.sessionInstanceId) {
+    return sidecar.sessionInstanceId === resolveSessionInstanceId(session);
+  }
+  return sidecar.sessionExpiresAt === undefined || sidecar.sessionExpiresAt === session.expiresAt;
 }
 
 export function createTtsPlaybackKvStore(input: {
@@ -242,7 +262,7 @@ export function createTtsPlaybackKvStore(input: {
         const cursorEntry = await kv.get(cursorKvKey(session.sessionId));
         if (isKvPut(cursorEntry)) {
           const cursor = cursorCodec.decode(cursorEntry.value);
-          if (sidecarMatchesSession(cursor.sessionExpiresAt, session.expiresAt)) {
+          if (sidecarMatchesSession(cursor, session)) {
             session.cursorOrdinal = cursor.cursorOrdinal;
             session.cursorUpdatedAt = cursor.cursorUpdatedAt;
           }
@@ -250,7 +270,7 @@ export function createTtsPlaybackKvStore(input: {
         const activityEntry = await kv.get(activityKvKey(session.sessionId));
         if (isKvPut(activityEntry)) {
           const activity = activityCodec.decode(activityEntry.value);
-          if (sidecarMatchesSession(activity.sessionExpiresAt, session.expiresAt)) {
+          if (sidecarMatchesSession(activity, session)) {
             session.playbackActive = activity.playbackActive;
           }
         }
@@ -270,7 +290,7 @@ export function createTtsPlaybackKvStore(input: {
       const cursorEntry = await kv.get(cursorKvKey(sessionId));
       if (isKvPut(cursorEntry)) {
         const cursor = cursorCodec.decode(cursorEntry.value);
-        if (sidecarMatchesSession(cursor.sessionExpiresAt, session.expiresAt)) {
+        if (sidecarMatchesSession(cursor, session)) {
           session.cursorOrdinal = cursor.cursorOrdinal;
           session.cursorUpdatedAt = cursor.cursorUpdatedAt;
         }
@@ -278,7 +298,7 @@ export function createTtsPlaybackKvStore(input: {
       const activityEntry = await kv.get(activityKvKey(sessionId));
       if (isKvPut(activityEntry)) {
         const activity = activityCodec.decode(activityEntry.value);
-        if (sidecarMatchesSession(activity.sessionExpiresAt, session.expiresAt)) {
+        if (sidecarMatchesSession(activity, session)) {
           session.playbackActive = activity.playbackActive;
         }
       }
@@ -288,6 +308,10 @@ export function createTtsPlaybackKvStore(input: {
     async putSessionIfNewer(state) {
       const kv = await input.getKv();
       const key = sessionKvKey(state.sessionId);
+      const nextState: TtsPlaybackSessionState = {
+        ...state,
+        sessionInstanceId: resolveSessionInstanceId(state),
+      };
       let accepted = false;
       // The canonical session id is reused across starts. The Next control
       // plane assigns later starts a later expiry, giving overlapping requests
@@ -296,11 +320,11 @@ export function createTtsPlaybackKvStore(input: {
         const entry = await kv.get(key);
         if (isKvPut(entry)) {
           const current = sessionCodec.decode(entry.value);
-          if (state.expiresAt <= current.expiresAt) {
-            return (state.generationRunId ?? null) === (current.generationRunId ?? null);
+          if (nextState.expiresAt <= current.expiresAt) {
+            return (nextState.generationRunId ?? null) === (current.generationRunId ?? null);
           }
           try {
-            await kv.update(key, sessionCodec.encode(state), entry.revision);
+            await kv.update(key, sessionCodec.encode(nextState), entry.revision);
             accepted = true;
             break;
           } catch (error) {
@@ -309,7 +333,7 @@ export function createTtsPlaybackKvStore(input: {
           }
         }
         try {
-          await kv.create(key, sessionCodec.encode(state));
+          await kv.create(key, sessionCodec.encode(nextState));
           accepted = true;
           break;
         } catch (error) {
@@ -318,11 +342,13 @@ export function createTtsPlaybackKvStore(input: {
       }
       if (!accepted) throw new Error(`Unable to create playback session ${state.sessionId} after repeated conflicts`);
       await kv.put(cursorKvKey(state.sessionId), cursorCodec.encode({
+        sessionInstanceId: nextState.sessionInstanceId,
         sessionExpiresAt: state.expiresAt,
         cursorOrdinal: Math.max(0, Math.floor(state.cursorOrdinal)),
         cursorUpdatedAt: state.cursorUpdatedAt,
       }));
       await kv.put(activityKvKey(state.sessionId), activityCodec.encode({
+        sessionInstanceId: nextState.sessionInstanceId,
         sessionExpiresAt: state.expiresAt,
         playbackActive: state.playbackActive !== false,
         updatedAt: state.updatedAt,
@@ -333,12 +359,13 @@ export function createTtsPlaybackKvStore(input: {
     async patchSession(sessionId, patch) {
       const kv = await input.getKv();
       const sessionEntry = await kv.get(sessionKvKey(sessionId));
-      const sessionExpiresAt = isKvPut(sessionEntry)
-        ? sessionCodec.decode(sessionEntry.value).expiresAt
-        : undefined;
+      if (!isKvPut(sessionEntry)) return;
+      const currentSession = sessionCodec.decode(sessionEntry.value);
+      const sessionInstanceId = resolveSessionInstanceId(currentSession);
       if (patch.playbackActive !== undefined) {
         await kv.put(activityKvKey(sessionId), activityCodec.encode({
-          ...(sessionExpiresAt === undefined ? {} : { sessionExpiresAt }),
+          sessionInstanceId,
+          sessionExpiresAt: currentSession.expiresAt,
           playbackActive: patch.playbackActive,
           updatedAt: patch.updatedAt ?? Date.now(),
         }));
@@ -347,7 +374,8 @@ export function createTtsPlaybackKvStore(input: {
       // never collides with the playhead heartbeat. Plain put, last-write-wins.
       if (patch.cursorOrdinal !== undefined && patch.cursorUpdatedAt !== undefined) {
         await kv.put(cursorKvKey(sessionId), cursorCodec.encode({
-          ...(sessionExpiresAt === undefined ? {} : { sessionExpiresAt }),
+          sessionInstanceId,
+          sessionExpiresAt: currentSession.expiresAt,
           cursorOrdinal: Math.max(0, Math.floor(patch.cursorOrdinal)),
           cursorUpdatedAt: patch.cursorUpdatedAt,
         }));
@@ -356,6 +384,7 @@ export function createTtsPlaybackKvStore(input: {
       delete recordPatch.cursorOrdinal;
       delete recordPatch.cursorUpdatedAt;
       delete recordPatch.playbackActive;
+      if (!currentSession.sessionInstanceId) recordPatch.sessionInstanceId = sessionInstanceId;
       // A bare `updatedAt` bump (the per-second cursor POST) doesn't justify
       // rewriting the record — the cursor key already carries a fresh timestamp.
       const meaningful = Object.keys(recordPatch).filter((field) => field !== 'updatedAt');
@@ -374,17 +403,80 @@ export function createTtsPlaybackKvStore(input: {
     async updateCursor(sessionId, ordinal, updatedAt = Date.now()) {
       const kv = await input.getKv();
       const sessionEntry = await kv.get(sessionKvKey(sessionId));
-      const sessionExpiresAt = isKvPut(sessionEntry)
-        ? sessionCodec.decode(sessionEntry.value).expiresAt
-        : undefined;
+      if (!isKvPut(sessionEntry)) return;
+      const session = sessionCodec.decode(sessionEntry.value);
       // Pure last-write-wins put on the cursor's own key. There is no CAS or
       // shared session rewrite; the session expiry tag makes stale puts
       // invisible if a newer canonical session wins while this write races.
       await kv.put(cursorKvKey(sessionId), cursorCodec.encode({
-        ...(sessionExpiresAt === undefined ? {} : { sessionExpiresAt }),
+        sessionInstanceId: resolveSessionInstanceId(session),
+        sessionExpiresAt: session.expiresAt,
         cursorOrdinal: Math.max(0, Math.floor(ordinal)),
         cursorUpdatedAt: updatedAt,
       }));
+    },
+
+    async watchGenerationInvalidation(sessionId, expectedGenerationRunId, onInvalidated) {
+      const kv = await input.getKv();
+      if (!kv.watch) return () => undefined;
+      const watcher = await kv.watch({
+        key: [sessionKvKey(sessionId), activityKvKey(sessionId)],
+        include: 'updates',
+      });
+      let stopped = false;
+      const stop = () => {
+        if (stopped) return;
+        stopped = true;
+        watcher.stop();
+      };
+      const invalidate = () => {
+        if (stopped) return;
+        onInvalidated();
+        stop();
+      };
+      const current = await this.getSession(sessionId);
+      if (
+        !current
+        || (current.status !== 'queued' && current.status !== 'running')
+        || (current.generationRunId ?? null) !== expectedGenerationRunId
+        || current.playbackActive === false
+        || Date.now() > current.expiresAt
+      ) {
+        invalidate();
+        return stop;
+      }
+      const expectedSessionInstanceId = resolveSessionInstanceId(current);
+      void (async () => {
+        try {
+          for await (const entry of watcher) {
+            if (stopped || entry.operation !== 'PUT') continue;
+            if (entry.key === sessionKvKey(sessionId)) {
+              const session = sessionCodec.decode(entry.value);
+              if (
+                resolveSessionInstanceId(session) !== expectedSessionInstanceId
+                || (session.status !== 'queued' && session.status !== 'running')
+                || (session.generationRunId ?? null) !== expectedGenerationRunId
+                || Date.now() > session.expiresAt
+              ) {
+                invalidate();
+              }
+              continue;
+            }
+            if (entry.key === activityKvKey(sessionId)) {
+              const activity = activityCodec.decode(entry.value);
+              if (
+                sidecarMatchesSession(activity, current)
+                && activity.playbackActive === false
+              ) {
+                invalidate();
+              }
+            }
+          }
+        } catch {
+          // Boundary checks remain the fallback if a NATS watch is interrupted.
+        }
+      })();
+      return stop;
     },
 
     async listSessions(scope) {

--- a/packages/compute-worker/src/playback/storage.ts
+++ b/packages/compute-worker/src/playback/storage.ts
@@ -89,7 +89,12 @@ export interface TtsPlaybackSessionStore {
     expectedGenerationRunId: string | null,
     patch: Partial<Omit<TtsPlaybackSessionState, 'schemaVersion' | 'sessionId'>>,
   ): Promise<boolean>;
-  updateCursor(sessionId: string, ordinal: number, updatedAt?: number): Promise<void>;
+  updateCursor(
+    sessionId: string,
+    ordinal: number,
+    expectedSessionInstanceId: string,
+    updatedAt?: number,
+  ): Promise<boolean>;
   watchGenerationInvalidation(
     sessionId: string,
     expectedGenerationRunId: string | null,
@@ -191,7 +196,7 @@ interface TtsPlaybackActivityRecord {
   updatedAt: number;
 }
 
-function resolveSessionInstanceId(session: TtsPlaybackSessionState): string {
+export function resolveTtsPlaybackSessionInstanceId(session: TtsPlaybackSessionState): string {
   return session.sessionInstanceId
     ?? `legacy:${session.expiresAt}:${session.generationRunId ?? 'initial'}`;
 }
@@ -201,7 +206,7 @@ function sidecarMatchesSession(
   session: TtsPlaybackSessionState,
 ): boolean {
   if (sidecar.sessionInstanceId) {
-    return sidecar.sessionInstanceId === resolveSessionInstanceId(session);
+    return sidecar.sessionInstanceId === resolveTtsPlaybackSessionInstanceId(session);
   }
   return sidecar.sessionExpiresAt === undefined || sidecar.sessionExpiresAt === session.expiresAt;
 }
@@ -253,6 +258,7 @@ export function createTtsPlaybackKvStore(input: {
       for (const entry of entries) {
         if (!isKvPut(entry)) continue;
         const session = sessionCodec.decode(entry.value);
+        session.sessionInstanceId = resolveTtsPlaybackSessionInstanceId(session);
         if (scope && !sessionMatchesScope(session, scope)) continue;
         sessions.push(session);
       }
@@ -285,6 +291,7 @@ export function createTtsPlaybackKvStore(input: {
       const entry = await kv.get(sessionKvKey(sessionId));
       if (!isKvPut(entry)) return null;
       const session = sessionCodec.decode(entry.value);
+      session.sessionInstanceId = resolveTtsPlaybackSessionInstanceId(session);
       // The cursor is authoritative on its own key; overlay it on top of the
       // record's last-known snapshot so callers see the live playhead.
       const cursorEntry = await kv.get(cursorKvKey(sessionId));
@@ -310,7 +317,7 @@ export function createTtsPlaybackKvStore(input: {
       const key = sessionKvKey(state.sessionId);
       const nextState: TtsPlaybackSessionState = {
         ...state,
-        sessionInstanceId: resolveSessionInstanceId(state),
+        sessionInstanceId: resolveTtsPlaybackSessionInstanceId(state),
       };
       let accepted = false;
       // The canonical session id is reused across starts. The Next control
@@ -361,7 +368,7 @@ export function createTtsPlaybackKvStore(input: {
       const sessionEntry = await kv.get(sessionKvKey(sessionId));
       if (!isKvPut(sessionEntry)) return;
       const currentSession = sessionCodec.decode(sessionEntry.value);
-      const sessionInstanceId = resolveSessionInstanceId(currentSession);
+      const sessionInstanceId = resolveTtsPlaybackSessionInstanceId(currentSession);
       if (patch.playbackActive !== undefined) {
         await kv.put(activityKvKey(sessionId), activityCodec.encode({
           sessionInstanceId,
@@ -400,20 +407,23 @@ export function createTtsPlaybackKvStore(input: {
       return patchSessionRecord(sessionId, recordPatch, expectedGenerationRunId);
     },
 
-    async updateCursor(sessionId, ordinal, updatedAt = Date.now()) {
+    async updateCursor(sessionId, ordinal, expectedSessionInstanceId, updatedAt = Date.now()) {
       const kv = await input.getKv();
       const sessionEntry = await kv.get(sessionKvKey(sessionId));
-      if (!isKvPut(sessionEntry)) return;
+      if (!isKvPut(sessionEntry)) return false;
       const session = sessionCodec.decode(sessionEntry.value);
+      if (resolveTtsPlaybackSessionInstanceId(session) !== expectedSessionInstanceId) return false;
       // Pure last-write-wins put on the cursor's own key. There is no CAS or
-      // shared session rewrite; the session expiry tag makes stale puts
-      // invisible if a newer canonical session wins while this write races.
+      // shared session rewrite. Stamp the captured instance id, rather than
+      // re-reading it after the request begins, so a replacement racing this
+      // put can only leave a sidecar that the successor ignores.
       await kv.put(cursorKvKey(sessionId), cursorCodec.encode({
-        sessionInstanceId: resolveSessionInstanceId(session),
+        sessionInstanceId: expectedSessionInstanceId,
         sessionExpiresAt: session.expiresAt,
         cursorOrdinal: Math.max(0, Math.floor(ordinal)),
         cursorUpdatedAt: updatedAt,
       }));
+      return true;
     },
 
     async watchGenerationInvalidation(sessionId, expectedGenerationRunId, onInvalidated) {
@@ -424,15 +434,29 @@ export function createTtsPlaybackKvStore(input: {
         include: 'updates',
       });
       let stopped = false;
+      let expiryTimer: ReturnType<typeof setTimeout> | null = null;
       const stop = () => {
         if (stopped) return;
         stopped = true;
+        if (expiryTimer !== null) {
+          clearTimeout(expiryTimer);
+          expiryTimer = null;
+        }
         watcher.stop();
       };
       const invalidate = () => {
         if (stopped) return;
         onInvalidated();
         stop();
+      };
+      const scheduleExpiryInvalidation = (expiresAt: number) => {
+        if (expiryTimer !== null) clearTimeout(expiryTimer);
+        const delayMs = Math.max(0, expiresAt - Date.now());
+        expiryTimer = setTimeout(() => {
+          expiryTimer = null;
+          if (Date.now() >= expiresAt) invalidate();
+          else scheduleExpiryInvalidation(expiresAt);
+        }, Math.min(delayMs, 2_147_483_647));
       };
       const current = await this.getSession(sessionId);
       if (
@@ -445,7 +469,8 @@ export function createTtsPlaybackKvStore(input: {
         invalidate();
         return stop;
       }
-      const expectedSessionInstanceId = resolveSessionInstanceId(current);
+      const expectedSessionInstanceId = resolveTtsPlaybackSessionInstanceId(current);
+      scheduleExpiryInvalidation(current.expiresAt);
       void (async () => {
         try {
           for await (const entry of watcher) {
@@ -453,12 +478,14 @@ export function createTtsPlaybackKvStore(input: {
             if (entry.key === sessionKvKey(sessionId)) {
               const session = sessionCodec.decode(entry.value);
               if (
-                resolveSessionInstanceId(session) !== expectedSessionInstanceId
+                resolveTtsPlaybackSessionInstanceId(session) !== expectedSessionInstanceId
                 || (session.status !== 'queued' && session.status !== 'running')
                 || (session.generationRunId ?? null) !== expectedGenerationRunId
                 || Date.now() > session.expiresAt
               ) {
                 invalidate();
+              } else {
+                scheduleExpiryInvalidation(session.expiresAt);
               }
               continue;
             }

--- a/packages/compute-worker/tests/unit/playback-audio-first.test.ts
+++ b/packages/compute-worker/tests/unit/playback-audio-first.test.ts
@@ -38,6 +38,19 @@ describe('playback audio-first segment generation', () => {
     vi.clearAllMocks();
   });
 
+  test('only reclaims leases from the same session incarnation', async () => {
+    const { leaseBelongsToPlaybackSession } = await import('../../src/jobs/playback/segment-generation');
+    const owner = JSON.stringify({
+      sessionId: 'session-1',
+      sessionInstanceId: 'instance-1',
+      generationRunId: 'run-1',
+    });
+
+    expect(leaseBelongsToPlaybackSession(owner, 'session-1', 'instance-1')).toBe(true);
+    expect(leaseBelongsToPlaybackSession(owner, 'session-1', 'instance-2')).toBe(false);
+    expect(leaseBelongsToPlaybackSession('session-1:window:run-1', 'session-1', 'instance-1')).toBe(false);
+  });
+
   test('publishes playable audio before alignment and backfills word timing afterward', async () => {
     let resolveAlignment!: (value: {
       alignments: Array<{
@@ -96,6 +109,7 @@ describe('playback audio-first segment generation', () => {
         planning: {},
         planObjectKey: 'plan-key',
       },
+      sessionInstanceId: 'instance-1',
       s3Prefix: 'openreader',
       segments: [{
         ordinal: 0,
@@ -199,6 +213,7 @@ describe('playback audio-first segment generation', () => {
         planning: {},
         planObjectKey: 'plan-key',
       },
+      sessionInstanceId: 'instance-2',
       s3Prefix: 'openreader',
       segments: [
         {
@@ -283,6 +298,7 @@ describe('playback audio-first segment generation', () => {
         planning: {},
         planObjectKey: 'plan-key',
       },
+      sessionInstanceId: 'instance-cancel',
       s3Prefix: 'openreader',
       segments: [{
         ordinal: 0,

--- a/packages/compute-worker/tests/unit/playback-audio-first.test.ts
+++ b/packages/compute-worker/tests/unit/playback-audio-first.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { TtsPlaybackSegmentMetadata, TtsPlaybackStorage } from '../../src/playback/storage';
 
 const mocks = vi.hoisted(() => ({
-  generateTTSBuffer: vi.fn(async () => Buffer.from('test-mp3')),
+  generateTTSBuffer: vi.fn<(
+    request?: unknown,
+    signal?: AbortSignal,
+  ) => Promise<Buffer>>(async () => Buffer.from('test-mp3')),
   runAlignment: vi.fn(),
 }));
 
@@ -232,5 +235,74 @@ describe('playback audio-first segment generation', () => {
 
     expect(sidecars.get(1)?.status).toBe('completed');
     expect(onSegmentCompleted).toHaveBeenCalledTimes(4);
+  });
+
+  test('aborts an in-flight provider request without persisting an error segment', async () => {
+    type GeneratedAudio = Awaited<ReturnType<typeof mocks.generateTTSBuffer>>;
+    mocks.generateTTSBuffer.mockImplementationOnce((_request: unknown, signal?: AbortSignal) => (
+      new Promise<GeneratedAudio>((_resolve, reject) => {
+        void _request;
+        const abort = () => reject(new DOMException('Aborted', 'AbortError'));
+        if (signal?.aborted) abort();
+        else signal?.addEventListener('abort', abort, { once: true });
+      })
+    ));
+    const sidecars: TtsPlaybackSegmentMetadata[] = [];
+    const playbackStorage = {
+      artifacts: {
+        readSegmentMetadata: vi.fn(async () => sidecars.at(-1) ?? null),
+        putSegmentMetadata: vi.fn(async (metadata: TtsPlaybackSegmentMetadata) => {
+          sidecars.push(metadata);
+          return 'sidecar-0';
+        }),
+        getScopeEpoch: vi.fn(async () => 0),
+      },
+    } as unknown as TtsPlaybackStorage;
+    const controller = new AbortController();
+    const putAudioObject = vi.fn(async () => undefined);
+
+    const { generateExplicitTtsPlaybackSegments } = await import('../../src/jobs/playback/segment-generation');
+    const run = generateExplicitTtsPlaybackSegments({
+      request: {
+        sessionId: 'session-cancel',
+        userId: 'user-1',
+        storageUserId: 'user-1',
+        documentId: 'document-1',
+        documentVersion: 1,
+        readerType: 'epub',
+        settingsHash: 'settings-1',
+        settingsJson: {
+          providerRef: 'local-kokoro',
+          providerType: 'custom-openai',
+          ttsModel: 'kokoro',
+          voice: 'af_heart',
+          nativeSpeed: 1,
+          ttsInstructions: '',
+          language: 'en',
+        },
+        planning: {},
+        planObjectKey: 'plan-key',
+      },
+      s3Prefix: 'openreader',
+      segments: [{
+        ordinal: 0,
+        segmentKey: 'segment-0',
+        text: 'This request should be aborted.',
+        locator: { readerType: 'epub', spineHref: 'chapter.xhtml', spineIndex: 0, charOffset: 0 },
+      }],
+      putAudioObject,
+      audioObjectExists: vi.fn(async () => false),
+      playbackStorage,
+      synthesisTimeoutMs: 30_000,
+      signal: controller.signal,
+    });
+
+    await vi.waitFor(() => expect(mocks.generateTTSBuffer).toHaveBeenCalledTimes(1));
+    controller.abort();
+    await expect(run).resolves.toBeUndefined();
+
+    expect(putAudioObject).not.toHaveBeenCalled();
+    expect(sidecars).toHaveLength(1);
+    expect(sidecars[0]).toMatchObject({ status: 'generating', error: null });
   });
 });

--- a/packages/compute-worker/tests/unit/playback-session-controller.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-controller.test.ts
@@ -78,6 +78,7 @@ function createFixture(
       patchSession,
       patchSessionIfGenerationRun,
       updateCursor,
+      async watchGenerationInvalidation() { return () => undefined; },
       async listSessions() { return [session]; },
       async cancelSessionsForScope() { return 0; },
     },
@@ -198,6 +199,18 @@ describe('playback session continuation controller', () => {
     );
 
     expect(fixture.enqueueOrReuse).not.toHaveBeenCalled();
+  });
+
+  test('supersedes active synthesis immediately when an audio range repositions the cursor', async () => {
+    const fixture = createFixture(playbackSession(), 'running');
+
+    await fixture.controller.updateCursor('session-1', 24, { ensureGeneration: true });
+
+    expect(fixture.enqueueOrReuse).toHaveBeenCalledTimes(1);
+    expect(fixture.currentSession()).toMatchObject({
+      cursorOrdinal: 24,
+      generationRunId: 'active:24',
+    });
   });
 
   test('refills audio while the active predecessor drains exact alignment', async () => {

--- a/packages/compute-worker/tests/unit/playback-session-controller.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-controller.test.ts
@@ -26,6 +26,7 @@ function playbackSession(overrides: Partial<PlaybackSessionRow> = {}): PlaybackS
     generationExtent: 'window',
     playbackActive: true,
     generationRunId: 'initial:12',
+    sessionInstanceId: 'instance-1',
     planning: { selectedOrdinal: 12 },
     generationStartOrdinal: 12,
     cursorOrdinal: 12,
@@ -50,8 +51,14 @@ function createFixture(
     error: null,
     request,
   }));
-  const updateCursor = vi.fn(async (_sessionId: string, ordinal: number, updatedAt?: number) => {
+  const updateCursor = vi.fn(async (
+    _sessionId: string,
+    ordinal: number,
+    _expectedSessionInstanceId: string,
+    updatedAt?: number,
+  ) => {
     session = { ...session, cursorOrdinal: ordinal, cursorUpdatedAt: updatedAt ?? Date.now() };
+    return true;
   });
   const patchSession = vi.fn(async (_sessionId: string, patch: Partial<PlaybackSessionRow>) => {
     session = { ...session, ...patch };
@@ -119,7 +126,12 @@ describe('playback session continuation controller', () => {
     );
     await fixture.controller.updateCursor('session-1', 13, { ensureGeneration: true });
 
-    expect(fixture.updateCursor).toHaveBeenCalledWith('session-1', 13, expect.any(Number));
+    expect(fixture.updateCursor).toHaveBeenCalledWith(
+      'session-1',
+      13,
+      'instance-1',
+      expect.any(Number),
+    );
     expect(fixture.enqueueOrReuse).not.toHaveBeenCalled();
   });
 

--- a/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
@@ -91,6 +91,7 @@ function createFixture() {
       async patchSession() {},
       async patchSessionIfGenerationRun() { return true; },
       async updateCursor() {},
+      async watchGenerationInvalidation() { return () => undefined; },
       async listSessions() { return []; },
       async cancelSessionsForScope() { return 0; },
     },

--- a/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
@@ -90,7 +90,7 @@ function createFixture() {
       async putSessionIfNewer() { return true; },
       async patchSession() {},
       async patchSessionIfGenerationRun() { return true; },
-      async updateCursor() {},
+      async updateCursor() { return true; },
       async watchGenerationInvalidation() { return () => undefined; },
       async listSessions() { return []; },
       async cancelSessionsForScope() { return 0; },

--- a/packages/compute-worker/tests/unit/playback-storage.test.ts
+++ b/packages/compute-worker/tests/unit/playback-storage.test.ts
@@ -147,6 +147,7 @@ describe('TTS playback storage', () => {
       settingsJson: { voice: 'v' },
       playbackActive: true,
       generationRunId: 'initial:0',
+      sessionInstanceId: 'instance-1',
       generationStartOrdinal: 0,
       cursorOrdinal: 0,
       cursorUpdatedAt: null,
@@ -156,7 +157,7 @@ describe('TTS playback storage', () => {
       updatedAt: 100,
     });
 
-    await store.updateCursor('session-1', 42, 200);
+    await store.updateCursor('session-1', 42, 'instance-1', 200);
 
     // The cursor lives on its own key (plain put, last-write-wins) and is
     // overlaid onto the record on read. A cursor update does NOT rewrite the
@@ -182,7 +183,7 @@ describe('TTS playback storage', () => {
     });
 
     await store.patchSession('session-1', { status: 'running', updatedAt: 400 });
-    await store.updateCursor('session-1', 43, 500);
+    await store.updateCursor('session-1', 43, 'instance-1', 500);
     expect(await store.getSession('session-1')).toMatchObject({
       status: 'running',
       cursorOrdinal: 43,
@@ -265,6 +266,85 @@ describe('TTS playback storage', () => {
     stop();
   });
 
+  test('invalidates generation when an otherwise idle session expires', async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    try {
+      const kv = new WatchableMemoryKv();
+      const store = createTtsPlaybackKvStore({ getKv: async () => kv });
+      await store.putSessionIfNewer({
+        schemaVersion: 1,
+        sessionId: 'session-expiring',
+        sessionInstanceId: 'instance-expiring',
+        userId: 'user-1',
+        storageUserId: 'storage-1',
+        documentId: 'a'.repeat(64),
+        documentVersion: 1,
+        readerType: 'epub',
+        status: 'running',
+        settingsHash: 'settings-hash',
+        settingsJson: { voice: 'v' },
+        playbackActive: true,
+        generationRunId: 'run-1',
+        generationStartOrdinal: 10,
+        cursorOrdinal: 10,
+        cursorUpdatedAt: 1_000,
+        planObjectKey: 'plans/session-expiring.json',
+        expiresAt: 1_500,
+        lastError: null,
+        updatedAt: 1_000,
+      });
+      const invalidated = vi.fn();
+      const stop = await store.watchGenerationInvalidation('session-expiring', 'run-1', invalidated);
+
+      await vi.advanceTimersByTimeAsync(501);
+      expect(invalidated).toHaveBeenCalledTimes(1);
+      stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('rejects a delayed cursor write captured from a replaced session', async () => {
+    const kv = new MemoryKv();
+    const store = createTtsPlaybackKvStore({ getKv: async () => kv });
+    const session = (
+      sessionInstanceId: string,
+      cursorOrdinal: number,
+      expiresAt: number,
+    ): Parameters<typeof store.putSessionIfNewer>[0] => ({
+      schemaVersion: 1,
+      sessionId: 'session-reused',
+      sessionInstanceId,
+      userId: 'user-1',
+      storageUserId: 'storage-1',
+      documentId: 'a'.repeat(64),
+      documentVersion: 1,
+      readerType: 'epub',
+      status: 'running',
+      settingsHash: 'settings-hash',
+      settingsJson: { voice: 'v' },
+      playbackActive: true,
+      generationRunId: 'run-1',
+      generationStartOrdinal: cursorOrdinal,
+      cursorOrdinal,
+      cursorUpdatedAt: expiresAt,
+      planObjectKey: 'plans/session-reused.json',
+      expiresAt,
+      lastError: null,
+      updatedAt: expiresAt,
+    });
+
+    await store.putSessionIfNewer(session('instance-old', 10, 1_000));
+    await store.putSessionIfNewer(session('instance-new', 30, 2_000));
+
+    expect(await store.updateCursor('session-reused', 11, 'instance-old', 1_500)).toBe(false);
+    expect(await store.getSession('session-reused')).toMatchObject({
+      sessionInstanceId: 'instance-new',
+      cursorOrdinal: 30,
+      cursorUpdatedAt: 2_000,
+    });
+  });
+
   test('hot cursor and activity updates never use CAS', async () => {
     // A KV that rejects every CAS write proves the hot client-owned paths stay
     // plain puts. Worker-owned session record patches intentionally use CAS.
@@ -287,6 +367,7 @@ describe('TTS playback storage', () => {
       status: 'queued',
       settingsHash: 'settings-hash',
       settingsJson: { voice: 'v' },
+      sessionInstanceId: 'instance-hot',
       generationStartOrdinal: 0,
       cursorOrdinal: 0,
       cursorUpdatedAt: null,
@@ -298,7 +379,9 @@ describe('TTS playback storage', () => {
 
     // Many racing cursor writers plus an activity update are all plain puts.
     await Promise.all([
-      ...Array.from({ length: 25 }, (_, i) => store.updateCursor('session-1', i, 1000 + i)),
+      ...Array.from({ length: 25 }, (_, i) => (
+        store.updateCursor('session-1', i, 'instance-hot', 1000 + i)
+      )),
       store.patchSession('session-1', { playbackActive: false, updatedAt: 1100 }),
       store.patchSession('session-1', { cursorOrdinal: 5, cursorUpdatedAt: 1200, updatedAt: 1200 }),
     ]);

--- a/packages/compute-worker/tests/unit/playback-storage.test.ts
+++ b/packages/compute-worker/tests/unit/playback-storage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import type { ArtifactStorage } from '../../src/infrastructure/storage';
 import type { KvEntryLike, KvStoreLike } from '../../src/infrastructure/nats-adapters';
 import {
@@ -76,6 +76,59 @@ class MemoryStorage implements ArtifactStorage {
   }
 }
 
+class WatchQueue<T> implements AsyncIterable<T> {
+  private readonly values: T[] = [];
+  private readonly waiters: Array<(value: IteratorResult<T>) => void> = [];
+  private stopped = false;
+
+  push(value: T): void {
+    const waiter = this.waiters.shift();
+    if (waiter) waiter({ done: false, value });
+    else this.values.push(value);
+  }
+
+  stop(): void {
+    this.stopped = true;
+    for (const waiter of this.waiters.splice(0)) waiter({ done: true, value: undefined });
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: async () => {
+        const value = this.values.shift();
+        if (value !== undefined) return { done: false, value };
+        if (this.stopped) return { done: true, value: undefined };
+        return new Promise<IteratorResult<T>>((resolve) => this.waiters.push(resolve));
+      },
+    };
+  }
+}
+
+class WatchableMemoryKv extends MemoryKv {
+  private readonly watches: Array<{ keys: Set<string>; queue: WatchQueue<unknown> }> = [];
+
+  override async put(key: string, data: Uint8Array): Promise<unknown> {
+    const result = await super.put(key, data);
+    for (const watch of this.watches) {
+      if (watch.keys.has(key)) {
+        watch.queue.push({ key, value: data, operation: 'PUT', revision: 1 });
+      }
+    }
+    return result;
+  }
+
+  async watch(options?: { key?: string | string[] }): Promise<never> {
+    const keys = Array.isArray(options?.key)
+      ? options.key
+      : options?.key
+        ? [options.key]
+        : [];
+    const queue = new WatchQueue<unknown>();
+    this.watches.push({ keys: new Set(keys), queue });
+    return queue as never;
+  }
+}
+
 describe('TTS playback storage', () => {
   test('stores sessions and updates cursors in KV', async () => {
     const kv = new MemoryKv();
@@ -136,6 +189,80 @@ describe('TTS playback storage', () => {
       playbackActive: false,
       updatedAt: 400,
     });
+  });
+
+  test('keeps cursor and pause intent authoritative when the session TTL rolls', async () => {
+    const kv = new MemoryKv();
+    const store = createTtsPlaybackKvStore({ getKv: async () => kv });
+
+    await store.putSessionIfNewer({
+      schemaVersion: 1,
+      sessionId: 'session-1',
+      userId: 'user-1',
+      storageUserId: 'storage-1',
+      documentId: 'a'.repeat(64),
+      documentVersion: 1,
+      readerType: 'epub',
+      status: 'running',
+      settingsHash: 'settings-hash',
+      settingsJson: { voice: 'v' },
+      playbackActive: true,
+      generationRunId: 'initial:10',
+      generationStartOrdinal: 10,
+      cursorOrdinal: 10,
+      cursorUpdatedAt: 100,
+      planObjectKey: 'plans/session-1.json',
+      expiresAt: 1_000,
+      lastError: null,
+      updatedAt: 100,
+    });
+
+    await store.patchSession('session-1', {
+      cursorOrdinal: 24,
+      cursorUpdatedAt: 200,
+      playbackActive: false,
+      expiresAt: 2_000,
+      updatedAt: 200,
+    });
+
+    expect(await store.getSession('session-1')).toMatchObject({
+      cursorOrdinal: 24,
+      cursorUpdatedAt: 200,
+      playbackActive: false,
+      expiresAt: 2_000,
+    });
+  });
+
+  test('pushes generation invalidation when playback is paused', async () => {
+    const kv = new WatchableMemoryKv();
+    const store = createTtsPlaybackKvStore({ getKv: async () => kv });
+    await store.putSessionIfNewer({
+      schemaVersion: 1,
+      sessionId: 'session-1',
+      userId: 'user-1',
+      storageUserId: 'storage-1',
+      documentId: 'a'.repeat(64),
+      documentVersion: 1,
+      readerType: 'epub',
+      status: 'running',
+      settingsHash: 'settings-hash',
+      settingsJson: { voice: 'v' },
+      playbackActive: true,
+      generationRunId: 'run-1',
+      generationStartOrdinal: 10,
+      cursorOrdinal: 10,
+      cursorUpdatedAt: 100,
+      planObjectKey: 'plans/session-1.json',
+      expiresAt: Date.now() + 60_000,
+      lastError: null,
+      updatedAt: 100,
+    });
+    const invalidated = vi.fn();
+    const stop = await store.watchGenerationInvalidation('session-1', 'run-1', invalidated);
+
+    await store.patchSession('session-1', { playbackActive: false, updatedAt: 200 });
+    await vi.waitFor(() => expect(invalidated).toHaveBeenCalledTimes(1));
+    stop();
   });
 
   test('hot cursor and activity updates never use CAS', async () => {

--- a/packages/tts/src/audio-format.ts
+++ b/packages/tts/src/audio-format.ts
@@ -334,16 +334,35 @@ export function getCbrSilenceSecond(signal?: AbortSignal): Promise<Buffer> {
  * post-generation `playbackRate` depend on. Segment audio is cached, so this one-time
  * transcode cost is amortized across every playback and MP3 export.
  */
-export async function normalizeToMp3(buffer: Buffer, signal?: AbortSignal): Promise<Buffer> {
+export async function normalizeToMp3(
+  buffer: Buffer,
+  signal?: AbortSignal,
+  context?: {
+    provider: string;
+    model: string;
+    textLength: number;
+    providerMs: number;
+  },
+): Promise<Buffer> {
   if (buffer.length === 0) return buffer;
 
+  const normalizationStartedAt = Date.now();
   const format = sniffAudioFormat(buffer);
   const transcoded = await transcodeToMp3(buffer, signal);
+  const normalizationMs = Date.now() - normalizationStartedAt;
   ttsLogger.info({
     event: 'tts.audio_format.normalized_to_mp3',
     sourceFormat: format,
     sourceBytes: buffer.length,
     outputBytes: transcoded.length,
+    normalizationMs,
+    ...(context ? {
+      provider: context.provider,
+      model: context.model,
+      textLength: context.textLength,
+      providerMs: context.providerMs,
+      totalMs: context.providerMs + normalizationMs,
+    } : {}),
   }, 'Normalized TTS audio to stream profile mp3');
   return transcoded;
 }

--- a/packages/tts/src/generate.ts
+++ b/packages/tts/src/generate.ts
@@ -709,15 +709,22 @@ async function runProviderRequest(
   signal: AbortSignal,
   upstreamSettings: ResolvedTtsUpstreamRuntimeSettings,
 ): Promise<Buffer> {
+  const providerStartedAt = Date.now();
   const raw = request.provider === 'replicate'
     ? await runReplicateRequest(request, signal, upstreamSettings.ttsUpstreamMaxRetries)
     : request.provider === 'speech-sdk'
       ? await runSpeechSdkRequest(request, signal, upstreamSettings)
       : await runOpenAiCompatibleRequest(request, signal, upstreamSettings);
+  const providerMs = Date.now() - providerStartedAt;
 
   // OpenAI-compatible servers (and some Replicate models) may emit wav/ogg/etc.;
   // Normalize to MP3 so playback storage and document export stay MP3-only.
-  return normalizeToMp3(raw, signal);
+  return normalizeToMp3(raw, signal, {
+    provider: request.provider,
+    model: request.model,
+    textLength: request.text.length,
+    providerMs,
+  });
 }
 
 async function runOpenAiCompatibleRequest(

--- a/src/lib/client/tts/playback-control.ts
+++ b/src/lib/client/tts/playback-control.ts
@@ -1,7 +1,6 @@
 import type { TtsPlaybackPhase } from '@/types/tts';
 
 export const PLAYBACK_START_BUFFER_WALL_MS = 10_000;
-export const PLAYBACK_START_MIN_SEGMENTS = 2;
 
 type PlaybackBufferSegment = {
   ordinal: number;
@@ -102,8 +101,11 @@ export function isPlaybackStartBufferReady(input: {
     0,
     buffer.durationMs - Math.max(0, Math.floor(input.offsetWithinStartSegmentMs ?? 0)),
   );
-  return buffer.segmentCount >= PLAYBACK_START_MIN_SEGMENTS
-    && playableDurationMs >= minimumWallMs * playbackRate;
+  // Duration, not segment count, is the meaningful underrun protection. One
+  // long generated paragraph can provide more runway than several headings;
+  // requiring a second segment in that case only adds a full provider round
+  // trip before playback can begin.
+  return playableDurationMs >= minimumWallMs * playbackRate;
 }
 
 export async function waitForPlaybackStartBuffer<T extends PlaybackStartLayout>(input: {

--- a/tests/unit/playback-control.vitest.spec.ts
+++ b/tests/unit/playback-control.vitest.spec.ts
@@ -103,6 +103,17 @@ describe('playback start buffer', () => {
     })).toBe(true);
   });
 
+  test('starts from one long segment once it supplies the full time buffer', () => {
+    expect(isPlaybackStartBufferReady({
+      segments: [
+        segment(20, 14_000),
+        segment(21, 8_000, false),
+      ],
+      startOrdinal: 20,
+      playbackRate: 1,
+    })).toBe(true);
+  });
+
   test('scales the media buffer for playback speed and permits a short document tail', () => {
     const buffered = [segment(30, 6_000), segment(31, 6_000), segment(32, 9_000, false)];
     expect(isPlaybackStartBufferReady({

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -1631,10 +1631,28 @@ that the local same-host acceptance runs did not exercise:
   during that download is therefore not evidence that exact Whisper alignment
   has already completed. Whisper artifact acquisition remains single-flight per
   worker process.
+- Cursor and play/pause sidecars now belong to a stable session incarnation,
+  rather than the session's rolling expiry. The previous expiry equality check
+  invalidated each cursor as soon as its heartbeat extended the TTL, so refill
+  and cancellation could keep observing the original cursor and active state.
+- Live jobs watch the canonical generation and activity KV keys. Pause and an
+  explicit range seek now abort the in-flight provider request through the
+  existing `AbortSignal`; they no longer wait for a long segment to finish.
+  A successor from the same canonical session may immediately reclaim the old
+  generation lease, while unrelated sessions continue to deduplicate work.
+- Startup readiness is based on contiguous playable wall time, not an arbitrary
+  minimum segment count. One long paragraph that already supplies the ten-second
+  runway can start immediately instead of waiting for another full provider
+  request; a short heading still waits for more real audio.
+- The existing normalized-audio log now separates provider time from MP3
+  normalization time and records text length. Deployed validation can therefore
+  distinguish slow synthesis from local transcoding before changing provider
+  concurrency or canonical segment sizing.
 
 Local verification passed the worker unit suite, root Vitest suite, application
 and worker type checks, changed-source lint, production build, compute boundary,
 route-error, and server-bundle guards, plus the complete 24-case Chromium/WebKit
 Playwright matrix with both real playback journeys. A subsequent deployed cold-model
 walkthrough should confirm bounded model progress, uninterrupted audio refill,
-and exact timing replacement after the model becomes ready.
+prompt pause/seek cancellation, and exact timing replacement after the model
+becomes ready.


### PR DESCRIPTION
## Summary

- keep cursor, playback, and pause state tied to a stable session instance instead of its rolling TTL
- supersede and abort irrelevant provider work promptly on pause or seek through NATS KV watches
- let a successor from the same session reclaim the generation lease without waiting
- base startup readiness on contiguous playable time and add provider/transcode timing to existing logs
- record the production findings and follow-up validation in the v5 playback architecture

## Why

The stale-sidecar guard introduced in #135 compared exact session expiry values, but that expiry advances on every heartbeat. A request could therefore extend the session and immediately make its newly written cursor and activity state invisible, compromising refill, pause cancellation, and seek positioning.

Active synthesis also observed supersession only between segments. With production generation taking roughly 25–30 seconds for some segments, a pause or seek could leave irrelevant provider work running for an entire synthesis request.

## Verification

- `pnpm test` — 129 files, 643 tests
- app and compute-worker TypeScript checks
- changed-source ESLint
- `pnpm build`
- OpenAPI, compute-boundary, and bundle guards
- `git diff --check`

No local Compose or Playwright stack was started, avoiding conflict with the existing test environment. Deployment and a repeat of the long-document production playback journey are the next validation step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playback can start once sufficient playable time is available, including from a single long segment.
  * Explicit seeks and pauses promptly stop in-progress audio generation.
  * Playback sessions retain cursor and activity state more reliably across expiry updates.

* **Performance & Reliability**
  * Successive playback generations can safely replace earlier runs.
  * Audio processing telemetry separates provider and MP3 conversion timing.
  * Delayed updates from replaced playback sessions are prevented from overwriting current state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->