### PR TITLE
fix(playback): harden progress delivery and stream recovery

### DIFF
--- a/packages/compute-worker/openapi.json
+++ b/packages/compute-worker/openapi.json
@@ -4415,6 +4415,254 @@
         }
       }
     },
+    "/v1/tts-playback/sessions/prepare": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
+                  "storageUserId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
+                  "documentId": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "documentVersion": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "readerType": {
+                    "type": "string",
+                    "enum": [
+                      "pdf",
+                      "epub",
+                      "html"
+                    ]
+                  },
+                  "settingsHash": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
+                  "settingsJson": {},
+                  "planning": {
+                    "type": "object",
+                    "properties": {
+                      "selectedOrdinal": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "maxBlockLength": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 20000
+                      },
+                      "enforceSourceBoundaries": {
+                        "type": "boolean"
+                      },
+                      "language": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 32
+                      },
+                      "documentSource": {
+                        "type": "object",
+                        "properties": {
+                          "namespace": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 128
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "skipBlockKinds": {
+                            "maxItems": 64,
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 64
+                            }
+                          },
+                          "extent": {
+                            "type": "string",
+                            "enum": [
+                              "section",
+                              "document"
+                            ]
+                          },
+                          "isPlainText": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "namespace",
+                          "extent"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "sessionId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "planObjectKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2048
+                  },
+                  "generationRunId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "expiresAt": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "aheadWindow": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 4096
+                  },
+                  "backgroundExtent": {
+                    "type": "string",
+                    "enum": [
+                      "section",
+                      "document"
+                    ]
+                  },
+                  "generationExtent": {
+                    "type": "string",
+                    "enum": [
+                      "window",
+                      "document"
+                    ]
+                  }
+                },
+                "required": [
+                  "userId",
+                  "storageUserId",
+                  "documentId",
+                  "documentVersion",
+                  "readerType",
+                  "settingsHash",
+                  "settingsJson",
+                  "planning",
+                  "sessionId",
+                  "planObjectKey"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sessionId": {
+                      "type": "string"
+                    },
+                    "sessionInstanceId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "sessionId",
+                    "sessionInstanceId"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/tts-playback/sessions/resolve": {
       "post": {
         "requestBody": {
@@ -5148,6 +5396,11 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "sessionInstanceId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  },
                   "ordinal": {
                     "type": "integer",
                     "minimum": 0,
@@ -5201,6 +5454,25 @@
             }
           },
           "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
             "description": "Default Response",
             "content": {
               "application/json": {

--- a/packages/compute-worker/openapi.json
+++ b/packages/compute-worker/openapi.json
@@ -4572,7 +4572,8 @@
                   "settingsJson",
                   "planning",
                   "sessionId",
-                  "planObjectKey"
+                  "planObjectKey",
+                  "generationRunId"
                 ],
                 "additionalProperties": false
               }
@@ -5434,6 +5435,55 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sessionId": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 128
+                    },
+                    "workerOpId": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "cursorOrdinal": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "playbackActive": {
+                      "type": "boolean"
+                    },
+                    "expiresAt": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "sessionId",
+                    "workerOpId",
+                    "cursorOrdinal",
+                    "playbackActive",
+                    "expiresAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
           "400": {
             "description": "Default Response",
             "content": {

--- a/packages/compute-worker/openapi.json
+++ b/packages/compute-worker/openapi.json
@@ -5417,6 +5417,7 @@
                   }
                 },
                 "required": [
+                  "sessionInstanceId",
                   "ordinal"
                 ],
                 "additionalProperties": false

--- a/packages/compute-worker/src/api/app.ts
+++ b/packages/compute-worker/src/api/app.ts
@@ -347,6 +347,7 @@ export async function createComputeWorkerApp(options: CreateComputeWorkerAppOpti
     pdfHardCapMs,
     ttsPlaybackSegmentTimeoutMs,
     s3Prefix,
+    logger: app.log,
   });
 
   const workerLoops = createWorkerLoopController({

--- a/packages/compute-worker/src/api/playback/operation-invalidation.ts
+++ b/packages/compute-worker/src/api/playback/operation-invalidation.ts
@@ -35,30 +35,41 @@ export async function invalidatePlaybackOperationsForScope(input: {
     return 0;
   }
 
+  const sessions = new Map<string, Promise<PlaybackSessionRow | null>>();
   const belongsToScope = async (state: StreamedOperationState): Promise<boolean> => {
-    if (state.kind !== 'tts_playback') return operationMatchesPlaybackResetScope(state, scope);
+    if (!operationMatchesPlaybackResetScope(state, scope)) return false;
+    if (state.kind !== 'tts_playback') return true;
     const subject = ttsPlaybackSubjectFromOperationKey(state.opKey);
     if (!subject) return false;
-    const session = await readSession(subject.sessionId).catch(() => null);
+    let pending = sessions.get(subject.sessionId);
+    if (!pending) {
+      pending = readSession(subject.sessionId).catch(() => null);
+      sessions.set(subject.sessionId, pending);
+    }
+    const session = await pending;
     return session?.storageUserId === scope.storageUserId;
   };
 
   const states = await operationStateStore.listOpStates();
   let invalidated = 0;
-  for (const state of states) {
-    if (!await belongsToScope(state)) continue;
-    const record = await operationStateStore.getOpStateRecord(state.opId);
-    if (!record || !await belongsToScope(record.state)) continue;
-    const updated = await orchestrator.markFailedIfUnchanged({
-      current: record.state,
-      expectedRevision: record.revision,
-      error: {
-        message: 'TTS playback cache was cleared',
-        code: 'TTS_PLAYBACK_CACHE_CLEARED',
-      },
-      updatedAt: now,
-    });
-    if (updated) invalidated += 1;
+  const candidates = states.filter((state) => state.status !== 'failed'
+    && operationMatchesPlaybackResetScope(state, scope));
+  for (let index = 0; index < candidates.length; index += 16) {
+    await Promise.all(candidates.slice(index, index + 16).map(async (state) => {
+      if (!await belongsToScope(state)) return;
+      const record = await operationStateStore.getOpStateRecord!(state.opId);
+      if (!record || record.state.status === 'failed' || !await belongsToScope(record.state)) return;
+      const updated = await orchestrator.markFailedIfUnchanged!({
+        current: record.state,
+        expectedRevision: record.revision,
+        error: {
+          message: 'TTS playback cache was cleared',
+          code: 'TTS_PLAYBACK_CACHE_CLEARED',
+        },
+        updatedAt: now,
+      });
+      if (updated) invalidated += 1;
+    }));
   }
   return invalidated;
 }

--- a/packages/compute-worker/src/api/playback/operation-invalidation.ts
+++ b/packages/compute-worker/src/api/playback/operation-invalidation.ts
@@ -43,7 +43,7 @@ export async function invalidatePlaybackOperationsForScope(input: {
     if (!subject) return false;
     let pending = sessions.get(subject.sessionId);
     if (!pending) {
-      pending = readSession(subject.sessionId).catch(() => null);
+      pending = readSession(subject.sessionId);
       sessions.set(subject.sessionId, pending);
     }
     const session = await pending;

--- a/packages/compute-worker/src/api/playback/session-controller.ts
+++ b/packages/compute-worker/src/api/playback/session-controller.ts
@@ -28,6 +28,7 @@ export interface PlaybackSessionController {
     requestBody: typeof ttsPlaybackOperationCreateSchema._output,
     status: PlaybackSessionRow['status'],
     workerOpId: string | null,
+    playbackActive?: boolean,
   ): Promise<void>;
 }
 
@@ -94,10 +95,13 @@ export function createPlaybackSessionController(
       ) return;
     }
 
-    // Cursor heartbeats and audio consumption are two signals for the same
-    // active cursor, not two independent generation runs. Sharing the token
-    // lets operation idempotency collapse races between both drivers.
-    const generationRunId = `active:${cursorOrdinal}`;
+    // Collapse concurrent signals for the same predecessor, not every future
+    // visit to this cursor. A paused/superseded job can finish successfully
+    // without filling its window; reusing its key would never resume synthesis.
+    const predecessor = hashOpKey(JSON.stringify([
+      resolveTtsPlaybackSessionInstanceId(session), session.generationRunId ?? null,
+    ])).slice(0, 24);
+    const generationRunId = `active:${cursorOrdinal}:${predecessor}`;
     const requestBody: typeof ttsPlaybackOperationCreateSchema._output = {
       sessionId: session.sessionId,
       userId: session.userId,
@@ -190,7 +194,7 @@ export function createPlaybackSessionController(
       // spawning one worker operation per spoken segment.
       if (session) await enqueueContinuationIfNeeded(session, now, 'stream');
     },
-    async putSessionState(requestBody, status, workerOpId) {
+    async putSessionState(requestBody, status, workerOpId, playbackActive = true) {
       const now = Date.now();
       const startOrdinal = Math.max(0, Math.floor(Number(requestBody.planning.selectedOrdinal)));
       await playbackStorage?.sessions.putSessionIfNewer({
@@ -208,7 +212,7 @@ export function createPlaybackSessionController(
         aheadWindow: requestBody.aheadWindow ?? null,
         backgroundExtent: requestBody.backgroundExtent ?? null,
         generationExtent: requestBody.generationExtent ?? null,
-        playbackActive: true,
+        playbackActive,
         generationRunId: requestBody.generationRunId ?? null,
         generationSatisfiedFromOrdinal: null,
         generationSatisfiedThroughOrdinal: null,

--- a/packages/compute-worker/src/api/playback/session-controller.ts
+++ b/packages/compute-worker/src/api/playback/session-controller.ts
@@ -138,21 +138,29 @@ export function createPlaybackSessionController(
         generationSatisfiedThroughOrdinal: null,
         updatedAt: now,
       },
+      resolveTtsPlaybackSessionInstanceId(session),
     );
     const claimedSession = await readModel.readSession(session.sessionId);
     if (
       !claimedSession
       || claimedSession.playbackActive === false
       || claimedSession.generationRunId !== generationRunId
+      || resolveTtsPlaybackSessionInstanceId(claimedSession)
+        !== resolveTtsPlaybackSessionInstanceId(session)
     ) return;
     await ensureOrphanedOpRecovery();
     const op = await deps.orchestrator.enqueueOrReuse(requestOp);
-    await playbackStorage.sessions.patchSessionIfGenerationRun(session.sessionId, generationRunId, {
-      status: op.status === 'failed' ? 'failed' : op.status === 'succeeded' ? 'succeeded' : 'running',
-      workerOpId: op.opId,
-      lastError: op.status === 'failed' ? (op.error?.message ?? 'Failed to enqueue playback continuation') : null,
-      updatedAt: now,
-    }).catch((error) => {
+    await playbackStorage.sessions.patchSessionIfGenerationRun(
+      session.sessionId,
+      generationRunId,
+      {
+        status: op.status === 'failed' ? 'failed' : op.status === 'succeeded' ? 'succeeded' : 'running',
+        workerOpId: op.opId,
+        lastError: op.status === 'failed' ? (op.error?.message ?? 'Failed to enqueue playback continuation') : null,
+        updatedAt: now,
+      },
+      resolveTtsPlaybackSessionInstanceId(session),
+    ).catch((error) => {
       app.log.warn(
         { sessionId: session.sessionId, opId: op.opId, error: toErrorMessage(error) },
         'tts.playback.resume_session_patch_failed',

--- a/packages/compute-worker/src/api/playback/session-read-model.ts
+++ b/packages/compute-worker/src/api/playback/session-read-model.ts
@@ -45,7 +45,6 @@ export interface PlaybackScope {
 }
 
 const SIDECAR_SCOPE_CACHE_MAX = 8;
-const SIDECAR_SCAN_AHEAD = 64;
 const SIDECAR_FETCH_BATCH = 32;
 const PLAN_CACHE_MAX = 4;
 
@@ -107,6 +106,7 @@ export function createPlaybackSessionReadModel(input: {
 }): PlaybackSessionReadModel {
   const { storage, playbackStorage } = input;
   const sidecarScopes = new Map<string, Map<number, TtsPlaybackSegmentMetadata>>();
+  const scopeCollections = new Map<string, Promise<Map<number, TtsPlaybackSegmentMetadata>>>();
   const plans = new Map<string, Array<{ ordinal: number; text: string }>>();
 
   const getScopeEpoch = async (session: PlaybackSessionRow): Promise<number> => {
@@ -174,26 +174,36 @@ export function createPlaybackSessionReadModel(input: {
   ): Promise<Map<number, TtsPlaybackSegmentMetadata>> => {
     const cacheEpoch = await getScopeEpoch(session);
     const cache = getSidecarScope(session, cacheEpoch);
-    const result = new Map<number, TtsPlaybackSegmentMetadata>(cache);
-    if (planLength <= 0) return result;
-    const cursor = Math.max(0, Math.floor(Number(session.cursorOrdinal ?? 0)));
-    const highestCached = cache.size > 0 ? Math.max(...cache.keys()) : -1;
-    const bandEnd = Math.min(planLength - 1, Math.max(highestCached, cursor) + SIDECAR_SCAN_AHEAD);
-    const ordinals: number[] = [];
-    for (let ordinal = 0; ordinal <= bandEnd; ordinal += 1) {
-      if (!isStableCompletedSidecar(cache.get(ordinal))) ordinals.push(ordinal);
+    if (planLength <= 0) return new Map(cache);
+    const key = scopeCacheKey(session, cacheEpoch);
+    const pending = scopeCollections.get(key);
+    if (pending) return pending;
+    const collect = (async () => {
+      const result = new Map<number, TtsPlaybackSegmentMetadata>(cache);
+      // List only this user/document/version/settings prefix. A deep cursor
+      // must not turn thousands of ungenerated ordinals into serial S3 batches.
+      // Existing exact timing remains cached across chapter changes; unfinished
+      // sidecars are re-read so proportional timing upgrades to exact timing.
+      const ordinals = (await playbackStorage?.artifacts.listSegmentOrdinals(session) ?? [])
+        .filter((ordinal) => ordinal < planLength && !isStableCompletedSidecar(cache.get(ordinal)));
+      for (let index = 0; index < ordinals.length; index += SIDECAR_FETCH_BATCH) {
+        const batch = ordinals.slice(index, index + SIDECAR_FETCH_BATCH);
+        const fetched = await Promise.all(batch.map((ordinal) => fetchSidecar(session, ordinal, cacheEpoch)));
+        batch.forEach((ordinal, batchIndex) => {
+          const sidecar = fetched[batchIndex];
+          if (!sidecar) return;
+          result.set(ordinal, sidecar);
+          if (isStableCompletedSidecar(sidecar)) cache.set(ordinal, sidecar);
+        });
+      }
+      return result;
+    })();
+    scopeCollections.set(key, collect);
+    try {
+      return await collect;
+    } finally {
+      if (scopeCollections.get(key) === collect) scopeCollections.delete(key);
     }
-    for (let index = 0; index < ordinals.length; index += SIDECAR_FETCH_BATCH) {
-      const batch = ordinals.slice(index, index + SIDECAR_FETCH_BATCH);
-      const fetched = await Promise.all(batch.map((ordinal) => fetchSidecar(session, ordinal, cacheEpoch)));
-      batch.forEach((ordinal, batchIndex) => {
-        const sidecar = fetched[batchIndex];
-        if (!sidecar) return;
-        result.set(ordinal, sidecar);
-        if (isStableCompletedSidecar(sidecar)) cache.set(ordinal, sidecar);
-      });
-    }
-    return result;
   };
 
   const readPlanSegments = async (

--- a/packages/compute-worker/src/api/playback/session-read-model.ts
+++ b/packages/compute-worker/src/api/playback/session-read-model.ts
@@ -1,5 +1,6 @@
 import { buildProportionalAlignment } from '@openreader/tts/segments';
 import type { ArtifactStorage } from '../../infrastructure/storage';
+import { toErrorMessage } from '../../infrastructure/errors';
 import type {
   TtsPlaybackSegmentMetadata,
   TtsPlaybackSessionState,
@@ -103,8 +104,9 @@ function scopeCacheKeyPrefix(scope: PlaybackScope): string {
 export function createPlaybackSessionReadModel(input: {
   storage: ArtifactStorage;
   playbackStorage?: TtsPlaybackStorage;
+  logger?: { warn(data: unknown, message?: string): void };
 }): PlaybackSessionReadModel {
-  const { storage, playbackStorage } = input;
+  const { storage, playbackStorage, logger } = input;
   const sidecarScopes = new Map<string, Map<number, TtsPlaybackSegmentMetadata>>();
   const scopeCollections = new Map<string, Promise<Map<number, TtsPlaybackSegmentMetadata>>>();
   const plans = new Map<string, Array<{ ordinal: number; text: string }>>();
@@ -184,7 +186,13 @@ export function createPlaybackSessionReadModel(input: {
       // must not turn thousands of ungenerated ordinals into serial S3 batches.
       // Existing exact timing remains cached across chapter changes; unfinished
       // sidecars are re-read so proportional timing upgrades to exact timing.
-      const ordinals = (await playbackStorage?.artifacts.listSegmentOrdinals(session) ?? [])
+      const ordinals = (await playbackStorage?.artifacts.listSegmentOrdinals(session).catch((error) => {
+        logger?.warn({
+          sessionId: session.sessionId,
+          error: toErrorMessage(error),
+        }, 'tts.playback.timeline_catalogue_read_failed');
+        return [];
+      }) ?? [])
         .filter((ordinal) => ordinal < planLength && !isStableCompletedSidecar(cache.get(ordinal)));
       for (let index = 0; index < ordinals.length; index += SIDECAR_FETCH_BATCH) {
         const batch = ordinals.slice(index, index + SIDECAR_FETCH_BATCH);

--- a/packages/compute-worker/src/api/playback/session-read-model.ts
+++ b/packages/compute-worker/src/api/playback/session-read-model.ts
@@ -361,6 +361,11 @@ export function createPlaybackSessionReadModel(input: {
           invalidated += 1;
         }
       }
+      for (const key of [...scopeCollections.keys()]) {
+        if (key === prefix || key.startsWith(`${prefix}\0`)) {
+          scopeCollections.delete(key);
+        }
+      }
       return invalidated;
     },
     invalidatePlansUnderPrefix(prefix) {

--- a/packages/compute-worker/src/api/routes.ts
+++ b/packages/compute-worker/src/api/routes.ts
@@ -27,7 +27,11 @@ export type { ComputeWorkerRouteDeps } from './route-context';
 
 /** Composition root for the compute worker's domain-owned route registrars. */
 export function registerComputeWorkerRoutes(context: ComputeWorkerRouteContext): void {
-  const playbackReadModel = createPlaybackSessionReadModel(context);
+  const playbackReadModel = createPlaybackSessionReadModel({
+    storage: context.storage,
+    playbackStorage: context.playbackStorage,
+    logger: context.app.log,
+  });
   const playbackController = createPlaybackSessionController(context, playbackReadModel);
 
   registerHealthRoutes(context);

--- a/packages/compute-worker/src/api/routes/cleanup.ts
+++ b/packages/compute-worker/src/api/routes/cleanup.ts
@@ -66,21 +66,38 @@ export function registerCleanupRoutes(
     }
     const { namespace, readerType, ...scope } = parsed.data;
     const now = Date.now();
+    const timed = async <T>(phase: string, run: () => Promise<T>): Promise<T> => {
+      const startedAt = Date.now();
+      try {
+        const result = await run();
+        app.log.info({ requestId: request.id, phase, durationMs: Date.now() - startedAt },
+          'tts.playback.cache_clear_phase');
+        return result;
+      } catch (error) {
+        app.log.warn({ requestId: request.id, phase, durationMs: Date.now() - startedAt },
+          'tts.playback.cache_clear_phase_failed');
+        throw error;
+      }
+    };
     await playbackStorage.artifacts.incrementScopeEpoch(scope, now);
-    const invalidatedPlaybackSessions = await playbackStorage.sessions.cancelSessionsForScope(scope, now);
+    const invalidatedPlaybackSessions = await timed('cancel_sessions', () => (
+      playbackStorage.sessions.cancelSessionsForScope(scope, now)
+    ));
     readModel.invalidateSidecarsForScope(scope);
-    const invalidatedJobOperations = await invalidatePlaybackOperationsForScope({
+    const invalidatedJobOperations = await timed('invalidate_operations', () => invalidatePlaybackOperationsForScope({
       scope,
       now,
       operationStateStore: deps.operationStateStore,
       orchestrator: deps.orchestrator,
       readSession: readModel.readSession,
-    });
-    const deleted = await clearTtsPlaybackArtifacts({
+    }));
+    const deleted = await timed('delete_objects', () => clearTtsPlaybackArtifacts({
       storage,
       s3Prefix,
       scope: { ...scope, namespace, ...(readerType ? { readerType } : {}) },
-    });
+    }));
+    app.log.info({ requestId: request.id, durationMs: Date.now() - now, ...deleted,
+      invalidatedPlaybackSessions, invalidatedJobOperations }, 'tts.playback.cache_clear_completed');
     return { ...deleted, invalidatedPlaybackSessions, invalidatedJobOperations };
   });
 

--- a/packages/compute-worker/src/api/routes/operations.ts
+++ b/packages/compute-worker/src/api/routes/operations.ts
@@ -142,11 +142,19 @@ export function registerOperationRoutes(context: ComputeWorkerRouteContext): voi
       unsubscribe = await deps.operationEventStream.subscribe({
         opId: params.data.opId,
         sinceEventId,
-        onEvent: (event) => {
+        onEvent: async (event) => {
           if (closed || event.snapshot.opId !== params.data.opId
             || event.snapshot.updatedAt < latestUpdatedAt) return;
-          latestUpdatedAt = event.snapshot.updatedAt;
           const nextSignature = JSON.stringify(event.snapshot);
+          // State is persisted before its event. If a replay has the same
+          // millisecond timestamp but differs from the initial state, confirm
+          // it is still the current state before allowing it to move the SSE
+          // stream backwards.
+          if (event.snapshot.updatedAt === latestUpdatedAt && nextSignature !== signature) {
+            const current = await getOpState(params.data.opId);
+            if (!current || JSON.stringify(current) !== nextSignature) return;
+          }
+          latestUpdatedAt = event.snapshot.updatedAt;
           if (nextSignature !== signature) {
             signature = nextSignature;
             markActivity('sse_event');

--- a/packages/compute-worker/src/api/routes/operations.ts
+++ b/packages/compute-worker/src/api/routes/operations.ts
@@ -133,6 +133,7 @@ export function registerOperationRoutes(context: ComputeWorkerRouteContext): voi
 
     try {
       let signature = JSON.stringify(initial);
+      let latestUpdatedAt = initial.updatedAt;
       writeSnapshot(initial, sinceEventId > 0 ? sinceEventId : 0);
       if (isTerminalStatus(initial.status)) return reply;
       keepalive = setInterval(() => {
@@ -142,7 +143,9 @@ export function registerOperationRoutes(context: ComputeWorkerRouteContext): voi
         opId: params.data.opId,
         sinceEventId,
         onEvent: (event) => {
-          if (closed || event.snapshot.opId !== params.data.opId) return;
+          if (closed || event.snapshot.opId !== params.data.opId
+            || event.snapshot.updatedAt < latestUpdatedAt) return;
+          latestUpdatedAt = event.snapshot.updatedAt;
           const nextSignature = JSON.stringify(event.snapshot);
           if (nextSignature !== signature) {
             signature = nextSignature;
@@ -156,7 +159,15 @@ export function registerOperationRoutes(context: ComputeWorkerRouteContext): voi
           closeStream();
         },
       });
-      await new Promise<void>((resolve) => request.raw.once('close', resolve));
+      // A replayed terminal event may close the response before subscribe()
+      // returns its teardown function. Do not leak that consumer or wait for
+      // a close event that has already happened.
+      if (closed) {
+        unsubscribe();
+        unsubscribe = null;
+      } else {
+        await new Promise<void>((resolve) => request.raw.once('close', resolve));
+      }
     } catch (error) {
       app.log.warn({ opId: params.data.opId, error: toErrorMessage(error) }, 'op events stream loop error');
     } finally {

--- a/packages/compute-worker/src/api/routes/playback/audio.ts
+++ b/packages/compute-worker/src/api/routes/playback/audio.ts
@@ -447,6 +447,7 @@ export function registerPlaybackAudioRoutes(
       }
     };
 
-    return Readable.from(streamRange());
+    // Backpressure is measured in bytes, not sixteen whole segment buffers.
+    return Readable.from(streamRange(), { objectMode: false, highWaterMark: 64 * 1024 });
   });
 }

--- a/packages/compute-worker/src/api/routes/playback/sessions.ts
+++ b/packages/compute-worker/src/api/routes/playback/sessions.ts
@@ -16,10 +16,12 @@ import {
   apiErrorResponseSchema,
   computeOperationSchema,
   jsonSchema,
+  ttsPlaybackCursorResponseSchema,
   ttsPlaybackCursorUpdateSchema,
   ttsPlaybackOperationCreateSchema,
   ttsPlaybackPlanOperationCreateSchema,
   ttsPlaybackSessionResolutionSchema,
+  ttsPlaybackSessionPrepareSchema,
   ttsPlaybackSessionResolveSchema,
 } from '../../schemas';
 
@@ -36,7 +38,7 @@ export function registerPlaybackSessionRoutes(
   // The browser activates this instance only after accepting the response.
   app.post('/v1/tts-playback/sessions/prepare', {
     schema: {
-      body: jsonSchema(ttsPlaybackOperationCreateSchema),
+      body: jsonSchema(ttsPlaybackSessionPrepareSchema),
       response: {
         200: {
           type: 'object',
@@ -47,9 +49,9 @@ export function registerPlaybackSessionRoutes(
       },
     },
   }, async (request, reply) => {
-    const parsed = ttsPlaybackOperationCreateSchema.safeParse(request.body);
+    const parsed = ttsPlaybackSessionPrepareSchema.safeParse(request.body);
     if (!parsed.success || parsed.data.planning.selectedOrdinal === undefined
-      || !parsed.data.generationRunId || parsed.data.generationExtent === 'document') {
+      || parsed.data.generationExtent === 'document') {
       return reply.code(400).send({ error: 'Live preparation requires a start ordinal and generation identity' });
     }
     if (!playbackStorage) return reply.code(503).send({ error: 'TTS playback storage is unavailable' });
@@ -169,7 +171,12 @@ export function registerPlaybackSessionRoutes(
         required: ['sessionId'],
       },
       body: jsonSchema(ttsPlaybackCursorUpdateSchema),
-      response: { 400: errorResponseSchema, 404: errorResponseSchema, 409: errorResponseSchema },
+      response: {
+        200: jsonSchema(ttsPlaybackCursorResponseSchema),
+        400: errorResponseSchema,
+        404: errorResponseSchema,
+        409: errorResponseSchema,
+      },
     },
   }, async (request, reply) => {
     const sessionId = (request.params as { sessionId?: string }).sessionId?.trim() ?? '';

--- a/packages/compute-worker/src/api/routes/playback/sessions.ts
+++ b/packages/compute-worker/src/api/routes/playback/sessions.ts
@@ -1,4 +1,5 @@
 import { buildTtsPlaybackCanonicalSessionId } from '@openreader/tts/playback-scope';
+import { resolveTtsPlaybackSessionInstanceId } from '../../../playback/storage';
 import { hashOpKey } from '../../../infrastructure/nats-adapters';
 import type { WorkerOperationRequest } from '../../../operations/contracts';
 import {
@@ -30,6 +31,35 @@ export function registerPlaybackSessionRoutes(
   controller: PlaybackSessionController,
 ): void {
   const { app, playbackStorage, getOpState } = context;
+
+  // A dropped/cancelled creation response must not leave synthesis running.
+  // The browser activates this instance only after accepting the response.
+  app.post('/v1/tts-playback/sessions/prepare', {
+    schema: {
+      body: jsonSchema(ttsPlaybackOperationCreateSchema),
+      response: {
+        200: {
+          type: 'object',
+          properties: { sessionId: { type: 'string' }, sessionInstanceId: { type: 'string' } },
+          required: ['sessionId', 'sessionInstanceId'], additionalProperties: false,
+        },
+        400: errorResponseSchema, 409: errorResponseSchema, 503: errorResponseSchema,
+      },
+    },
+  }, async (request, reply) => {
+    const parsed = ttsPlaybackOperationCreateSchema.safeParse(request.body);
+    if (!parsed.success || parsed.data.planning.selectedOrdinal === undefined
+      || !parsed.data.generationRunId || parsed.data.generationExtent === 'document') {
+      return reply.code(400).send({ error: 'Live preparation requires a start ordinal and generation identity' });
+    }
+    if (!playbackStorage) return reply.code(503).send({ error: 'TTS playback storage is unavailable' });
+    await controller.putSessionState(parsed.data, 'queued', null, false);
+    const session = await readModel.readSession(parsed.data.sessionId);
+    if (!session || session.generationRunId !== parsed.data.generationRunId) {
+      return reply.code(409).send({ error: 'Playback preparation was superseded' });
+    }
+    return { sessionId: session.sessionId, sessionInstanceId: resolveTtsPlaybackSessionInstanceId(session) };
+  });
 
   app.post('/v1/tts-playback/sessions/resolve', {
     schema: {
@@ -139,7 +169,7 @@ export function registerPlaybackSessionRoutes(
         required: ['sessionId'],
       },
       body: jsonSchema(ttsPlaybackCursorUpdateSchema),
-      response: { 400: errorResponseSchema, 404: errorResponseSchema },
+      response: { 400: errorResponseSchema, 404: errorResponseSchema, 409: errorResponseSchema },
     },
   }, async (request, reply) => {
     const sessionId = (request.params as { sessionId?: string }).sessionId?.trim() ?? '';
@@ -158,6 +188,10 @@ export function registerPlaybackSessionRoutes(
       return { error: 'Playback session not found' };
     }
     const now = Date.now();
+    const sessionInstanceId = resolveTtsPlaybackSessionInstanceId(session);
+    if (parsed.data.sessionInstanceId !== undefined && parsed.data.sessionInstanceId !== sessionInstanceId) {
+      return reply.code(409).send({ error: 'Playback session was replaced' });
+    }
     await playbackStorage?.sessions.patchSession(sessionId, {
       cursorOrdinal: parsed.data.ordinal,
       cursorUpdatedAt: now,
@@ -166,20 +200,21 @@ export function registerPlaybackSessionRoutes(
         : { playbackActive: parsed.data.playbackActive }),
       ...(parsed.data.expiresAt === undefined ? {} : { expiresAt: parsed.data.expiresAt }),
       updatedAt: now,
-    });
-    const nextSession = {
-      ...session,
-      cursorOrdinal: parsed.data.ordinal,
-      cursorUpdatedAt: now,
-      playbackActive: parsed.data.playbackActive ?? session.playbackActive,
-      expiresAt: parsed.data.expiresAt ?? session.expiresAt,
-      updatedAt: now,
-    };
+    }, sessionInstanceId);
+    const nextSession = await readModel.readSession(sessionId);
+    if (!nextSession || resolveTtsPlaybackSessionInstanceId(nextSession) !== sessionInstanceId) {
+      return reply.code(409).send({ error: 'Playback session was replaced' });
+    }
     if (nextSession.playbackActive !== false) {
       await controller.enqueueContinuationIfNeeded(nextSession, now, 'cursor');
     }
+    const currentSession = await readModel.readSession(sessionId);
+    if (!currentSession || resolveTtsPlaybackSessionInstanceId(currentSession) !== sessionInstanceId) {
+      return reply.code(409).send({ error: 'Playback session was replaced' });
+    }
     return {
       sessionId,
+      workerOpId: currentSession?.workerOpId ?? null,
       cursorOrdinal: parsed.data.ordinal,
       playbackActive: nextSession.playbackActive !== false,
       expiresAt: parsed.data.expiresAt ?? session.expiresAt,

--- a/packages/compute-worker/src/api/routes/playback/sessions.ts
+++ b/packages/compute-worker/src/api/routes/playback/sessions.ts
@@ -196,7 +196,7 @@ export function registerPlaybackSessionRoutes(
     }
     const now = Date.now();
     const sessionInstanceId = resolveTtsPlaybackSessionInstanceId(session);
-    if (parsed.data.sessionInstanceId !== undefined && parsed.data.sessionInstanceId !== sessionInstanceId) {
+    if (parsed.data.sessionInstanceId !== sessionInstanceId) {
       return reply.code(409).send({ error: 'Playback session was replaced' });
     }
     await playbackStorage?.sessions.patchSession(sessionId, {

--- a/packages/compute-worker/src/api/schemas.ts
+++ b/packages/compute-worker/src/api/schemas.ts
@@ -133,12 +133,24 @@ export const ttsPlaybackOperationCreateSchema = ttsPlaybackPlanOperationCreateSc
   generationExtent: z.enum(['window', 'document']).optional(),
 }).strict();
 
+export const ttsPlaybackSessionPrepareSchema = ttsPlaybackOperationCreateSchema.extend({
+  generationRunId: z.string().trim().min(1).max(128),
+}).strict();
+
 export const ttsPlaybackCursorUpdateSchema = z.object({
   sessionInstanceId: z.string().trim().min(1).max(256).optional(),
   ordinal: z.number().int().nonnegative(),
   playbackActive: z.boolean().optional(),
   expiresAt: z.number().int().positive().optional(),
 });
+
+export const ttsPlaybackCursorResponseSchema = z.object({
+  sessionId: z.string().trim().min(1).max(128),
+  workerOpId: z.string().trim().min(1).nullable(),
+  cursorOrdinal: z.number().int().nonnegative(),
+  playbackActive: z.boolean(),
+  expiresAt: z.number().int().positive(),
+}).strict();
 
 export const ttsPlaybackCacheClearSchema = z.object({
   storageUserId: z.string().trim().min(1).max(256),

--- a/packages/compute-worker/src/api/schemas.ts
+++ b/packages/compute-worker/src/api/schemas.ts
@@ -134,6 +134,7 @@ export const ttsPlaybackOperationCreateSchema = ttsPlaybackPlanOperationCreateSc
 }).strict();
 
 export const ttsPlaybackCursorUpdateSchema = z.object({
+  sessionInstanceId: z.string().trim().min(1).max(256).optional(),
   ordinal: z.number().int().nonnegative(),
   playbackActive: z.boolean().optional(),
   expiresAt: z.number().int().positive().optional(),

--- a/packages/compute-worker/src/api/schemas.ts
+++ b/packages/compute-worker/src/api/schemas.ts
@@ -138,7 +138,7 @@ export const ttsPlaybackSessionPrepareSchema = ttsPlaybackOperationCreateSchema.
 }).strict();
 
 export const ttsPlaybackCursorUpdateSchema = z.object({
-  sessionInstanceId: z.string().trim().min(1).max(256).optional(),
+  sessionInstanceId: z.string().trim().min(1).max(256),
   ordinal: z.number().int().nonnegative(),
   playbackActive: z.boolean().optional(),
   expiresAt: z.number().int().positive().optional(),

--- a/packages/compute-worker/src/infrastructure/nats-adapters.ts
+++ b/packages/compute-worker/src/infrastructure/nats-adapters.ts
@@ -124,12 +124,16 @@ export class JetStreamOperationStateStore<Result = unknown> implements Operation
 
   async listOpStates(): Promise<OperationState<Result>[]> {
     const kv = await this.getKv();
-    const keys = await kv.keys('op_state.*');
+    const keys: string[] = [];
+    for await (const key of await kv.keys('op_state.*')) keys.push(key);
     const states: OperationState<Result>[] = [];
-    for await (const key of keys) {
-      const entry = await kv.get(key);
-      if (!isPut(entry)) continue;
-      states.push(this.opStateCodec.decode(entry.value));
+    // Remote NATS round trips dominate this scan in production. Bound the
+    // fan-out instead of serializing every historical operation read.
+    for (let index = 0; index < keys.length; index += 32) {
+      const entries = await Promise.all(keys.slice(index, index + 32).map((key) => kv.get(key)));
+      for (const entry of entries) {
+        if (isPut(entry)) states.push(this.opStateCodec.decode(entry.value));
+      }
     }
     return states;
   }
@@ -219,7 +223,10 @@ export class JetStreamOperationEventStream<Result = unknown> implements Operatio
     const config = {
       name,
       ack_policy: AckPolicy.None,
-      deliver_policy: since > 0 ? DeliverPolicy.StartSequence : (input.replayOnly ? DeliverPolicy.All : DeliverPolicy.New),
+      // The HTTP route reads its initial snapshot before creating this
+      // consumer. Replay the latest event for this subject to cover a job
+      // finishing in that gap; New would lose the terminal update forever.
+      deliver_policy: since > 0 ? DeliverPolicy.StartSequence : (input.replayOnly ? DeliverPolicy.All : DeliverPolicy.Last),
       replay_policy: ReplayPolicy.Instant,
       filter_subject: subject,
       max_deliver: 1,

--- a/packages/compute-worker/src/jobs/context.ts
+++ b/packages/compute-worker/src/jobs/context.ts
@@ -8,4 +8,5 @@ export interface JobHandlerContext {
   pdfHardCapMs: number;
   ttsPlaybackSegmentTimeoutMs: number;
   s3Prefix: string;
+  logger?: { warn(data: unknown, message?: string): void };
 }

--- a/packages/compute-worker/src/jobs/playback/playback-job.ts
+++ b/packages/compute-worker/src/jobs/playback/playback-job.ts
@@ -118,14 +118,19 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
       const cacheEpoch = await readCurrentCacheEpoch();
       const completedOrdinals = new Set<number>();
       const erroredOrdinals = new Set<number>();
-      for (let index = 0; index < plannedSegments.length; index += 32) {
-        const sidecars = await Promise.all(plannedSegments.slice(index, index + 32).map((segment) =>
+      const plannedOrdinals = new Set(plannedSegments.map((segment) => segment.ordinal));
+      // Discover existing cache entries instead of issuing an S3 GET for every
+      // segment in the book before the requested segment can start synthesis.
+      const cachedOrdinals = (await playbackStorage.artifacts.listSegmentOrdinals(parsed))
+        .filter((ordinal) => plannedOrdinals.has(ordinal));
+      for (let index = 0; index < cachedOrdinals.length; index += 32) {
+        const sidecars = await Promise.all(cachedOrdinals.slice(index, index + 32).map((ordinal) =>
           playbackStorage.artifacts.readSegmentMetadata({
             storageUserId: parsed.storageUserId,
             documentId: parsed.documentId,
             documentVersion: parsed.documentVersion,
             settingsHash: parsed.settingsHash,
-            ordinal: segment.ordinal,
+            ordinal,
           }).catch(() => null)));
         sidecars.forEach((sidecar) => {
           if (sidecar?.status !== 'completed' || !sidecar.audioKey) return;

--- a/packages/compute-worker/src/jobs/playback/playback-job.ts
+++ b/packages/compute-worker/src/jobs/playback/playback-job.ts
@@ -6,6 +6,7 @@ import {
 import { resolveTtsPlaybackSessionInstanceId } from '../../playback/storage';
 import type { JobHandlerContext } from '../context';
 import { createModelDownloadProgressReporter } from '../model-download-progress';
+import { toErrorMessage } from '../../infrastructure/errors';
 import { resolveAndPersistTtsPlaybackPlan } from './plan';
 import { generateExplicitTtsPlaybackSegments } from './segment-generation';
 import { ttsPlaybackRequestSchema } from './schemas';
@@ -121,7 +122,13 @@ export function createTtsPlaybackHandler(input: JobHandlerContext) {
       const plannedOrdinals = new Set(plannedSegments.map((segment) => segment.ordinal));
       // Discover existing cache entries instead of issuing an S3 GET for every
       // segment in the book before the requested segment can start synthesis.
-      const cachedOrdinals = (await playbackStorage.artifacts.listSegmentOrdinals(parsed))
+      const cachedOrdinals = (await playbackStorage.artifacts.listSegmentOrdinals(parsed).catch((error) => {
+        input.logger?.warn({
+          sessionId: parsed.sessionId,
+          error: toErrorMessage(error),
+        }, 'tts.playback.cache_catalogue_read_failed');
+        return [];
+      }))
         .filter((ordinal) => plannedOrdinals.has(ordinal));
       for (let index = 0; index < cachedOrdinals.length; index += 32) {
         const sidecars = await Promise.all(cachedOrdinals.slice(index, index + 32).map((ordinal) =>

--- a/packages/compute-worker/src/playback/storage.ts
+++ b/packages/compute-worker/src/playback/storage.ts
@@ -107,6 +107,8 @@ export interface TtsPlaybackSessionStore {
 export interface TtsPlaybackSegmentArtifactStore {
   /** S3 key of one segment's sidecar, addressable directly from the plan ordinal. */
   sidecarKey(input: TtsPlaybackSegmentScope & { ordinal: number }): string;
+  /** Discover stored ordinals without issuing an object-store miss for every ungenerated segment. */
+  listSegmentOrdinals(scope: TtsPlaybackSegmentScope): Promise<number[]>;
   /** Write one segment's sidecar (plain put to its own key — race-free). */
   putSegmentMetadata(metadata: TtsPlaybackSegmentMetadata): Promise<string>;
   /** Read one segment's sidecar by ordinal. Returns null when not yet generated. */
@@ -555,6 +557,17 @@ export function createTtsPlaybackSegmentArtifactStore(input: {
 
   return {
     sidecarKey,
+
+    async listSegmentOrdinals(scope) {
+      const prefix = sidecarKey({ ...scope, ordinal: 0 }).slice(0, -'0.json'.length);
+      const keys = await input.storage.listPrefix(prefix);
+      return [...new Set(keys.flatMap((key) => {
+        if (!key.startsWith(prefix)) return [];
+        const match = /^(\d+)\.json$/.exec(key.slice(prefix.length));
+        const ordinal = match ? Number(match[1]) : NaN;
+        return Number.isSafeInteger(ordinal) ? [ordinal] : [];
+      }))].sort((a, b) => a - b);
+    },
 
     async putSegmentMetadata(metadata) {
       // One segment → one immutable object at its own key. Plain put, no shared

--- a/packages/compute-worker/src/playback/storage.ts
+++ b/packages/compute-worker/src/playback/storage.ts
@@ -83,7 +83,7 @@ export interface TtsPlaybackResetScope {
 export interface TtsPlaybackSessionStore {
   getSession(sessionId: string): Promise<TtsPlaybackSessionState | null>;
   putSessionIfNewer(state: TtsPlaybackSessionState): Promise<boolean>;
-  patchSession(sessionId: string, patch: Partial<Omit<TtsPlaybackSessionState, 'schemaVersion' | 'sessionId'>>): Promise<void>;
+  patchSession(sessionId: string, patch: Partial<Omit<TtsPlaybackSessionState, 'schemaVersion' | 'sessionId'>>, expectedSessionInstanceId?: string): Promise<void>;
   patchSessionIfGenerationRun(
     sessionId: string,
     expectedGenerationRunId: string | null,
@@ -223,6 +223,7 @@ export function createTtsPlaybackKvStore(input: {
     sessionId: string,
     recordPatch: Partial<TtsPlaybackSessionState>,
     expectedGenerationRunId?: string | null,
+    expectedSessionInstanceId?: string,
   ): Promise<boolean> => {
     const kv = await input.getKv();
     const key = sessionKvKey(sessionId);
@@ -230,6 +231,8 @@ export function createTtsPlaybackKvStore(input: {
       const entry = await kv.get(key);
       if (!isKvPut(entry)) return false;
       const current = sessionCodec.decode(entry.value);
+      if (expectedSessionInstanceId !== undefined
+        && resolveTtsPlaybackSessionInstanceId(current) !== expectedSessionInstanceId) return false;
       if (
         expectedGenerationRunId !== undefined
         && (current.generationRunId ?? null) !== expectedGenerationRunId
@@ -365,12 +368,13 @@ export function createTtsPlaybackKvStore(input: {
       return true;
     },
 
-    async patchSession(sessionId, patch) {
+    async patchSession(sessionId, patch, expectedSessionInstanceId) {
       const kv = await input.getKv();
       const sessionEntry = await kv.get(sessionKvKey(sessionId));
       if (!isKvPut(sessionEntry)) return;
       const currentSession = sessionCodec.decode(sessionEntry.value);
       const sessionInstanceId = resolveTtsPlaybackSessionInstanceId(currentSession);
+      if (expectedSessionInstanceId !== undefined && sessionInstanceId !== expectedSessionInstanceId) return;
       if (patch.playbackActive !== undefined) {
         await kv.put(activityKvKey(sessionId), activityCodec.encode({
           sessionInstanceId,
@@ -398,7 +402,7 @@ export function createTtsPlaybackKvStore(input: {
       // rewriting the record — the cursor key already carries a fresh timestamp.
       const meaningful = Object.keys(recordPatch).filter((field) => field !== 'updatedAt');
       if (meaningful.length === 0) return;
-      await patchSessionRecord(sessionId, recordPatch);
+      await patchSessionRecord(sessionId, recordPatch, undefined, sessionInstanceId);
     },
 
     async patchSessionIfGenerationRun(sessionId, expectedGenerationRunId, patch) {

--- a/packages/compute-worker/src/playback/storage.ts
+++ b/packages/compute-worker/src/playback/storage.ts
@@ -88,6 +88,7 @@ export interface TtsPlaybackSessionStore {
     sessionId: string,
     expectedGenerationRunId: string | null,
     patch: Partial<Omit<TtsPlaybackSessionState, 'schemaVersion' | 'sessionId'>>,
+    expectedSessionInstanceId?: string,
   ): Promise<boolean>;
   updateCursor(
     sessionId: string,
@@ -405,12 +406,22 @@ export function createTtsPlaybackKvStore(input: {
       await patchSessionRecord(sessionId, recordPatch, undefined, sessionInstanceId);
     },
 
-    async patchSessionIfGenerationRun(sessionId, expectedGenerationRunId, patch) {
+    async patchSessionIfGenerationRun(
+      sessionId,
+      expectedGenerationRunId,
+      patch,
+      expectedSessionInstanceId,
+    ) {
       const recordPatch: Partial<TtsPlaybackSessionState> = { ...patch };
       delete recordPatch.cursorOrdinal;
       delete recordPatch.cursorUpdatedAt;
       delete recordPatch.playbackActive;
-      return patchSessionRecord(sessionId, recordPatch, expectedGenerationRunId);
+      return patchSessionRecord(
+        sessionId,
+        recordPatch,
+        expectedGenerationRunId,
+        expectedSessionInstanceId,
+      );
     },
 
     async updateCursor(sessionId, ordinal, expectedSessionInstanceId, updatedAt = Date.now()) {

--- a/packages/compute-worker/tests/api/routes.test.ts
+++ b/packages/compute-worker/tests/api/routes.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createComputeWorkerApp } from '../../src/api/app';
 import { buildTtsPlaybackOperationKey } from '../../src/operations/keys';
 import { FakeControlPlane } from '../fixtures/fake-control-plane';
@@ -405,6 +405,26 @@ describe('compute worker API routes', () => {
     expect(stream.body).toContain('event: snapshot');
     expect(stream.body).toContain('id: 7');
     expect(stream.body).toContain('"status":"succeeded"');
+  });
+
+  test('cleans up a subscription that replays completion before returning its teardown', async () => {
+    const now = Date.now();
+    const initial = {
+      opId: 'op-gap', opKey: 'k-gap', kind: 'pdf_layout' as const,
+      jobId: 'job-gap', status: 'running' as const, queuedAt: now, updatedAt: now,
+    };
+    fake.seedState(initial);
+    const stop = vi.fn();
+    vi.spyOn(fake.deps.operationEventStream, 'subscribe').mockImplementationOnce(async ({ onEvent }) => {
+      await onEvent({ eventId: 1, snapshot: { ...initial, status: 'queued', updatedAt: now - 1 } });
+      await onEvent({ eventId: 2, snapshot: { ...initial, status: 'succeeded', updatedAt: now + 1 } });
+      return stop;
+    });
+    const stream = await runtime.app.inject({ method: 'GET', url: '/v1/operations/op-gap/events', headers: AUTH });
+    expect(stream.body).toContain('"status":"running"');
+    expect(stream.body).toContain('"status":"succeeded"');
+    expect(stream.body).not.toContain('"status":"queued"');
+    await vi.waitFor(() => expect(stop).toHaveBeenCalledOnce());
   });
 
   test('streams TTS playback completed-count progress in SSE snapshots', async () => {

--- a/packages/compute-worker/tests/api/routes.test.ts
+++ b/packages/compute-worker/tests/api/routes.test.ts
@@ -427,6 +427,30 @@ describe('compute worker API routes', () => {
     await vi.waitFor(() => expect(stop).toHaveBeenCalledOnce());
   });
 
+  test('does not replace the initial operation snapshot with an older equal-time replay', async () => {
+    const now = Date.now();
+    const initial = {
+      opId: 'op-equal-time', opKey: 'k-equal-time', kind: 'pdf_layout' as const,
+      jobId: 'job-equal-time', status: 'running' as const, queuedAt: now, updatedAt: now,
+    };
+    fake.seedState(initial);
+    const stop = vi.fn();
+    vi.spyOn(fake.deps.operationEventStream, 'subscribe').mockImplementationOnce(async ({ onEvent }) => {
+      await onEvent({ eventId: 1, snapshot: { ...initial, status: 'queued' } });
+      const succeeded = { ...initial, status: 'succeeded' as const };
+      fake.seedState(succeeded);
+      await onEvent({ eventId: 2, snapshot: succeeded });
+      return stop;
+    });
+    const stream = await runtime.app.inject({
+      method: 'GET', url: '/v1/operations/op-equal-time/events', headers: AUTH,
+    });
+    expect(stream.body).toContain('"status":"running"');
+    expect(stream.body).toContain('"status":"succeeded"');
+    expect(stream.body).not.toContain('"status":"queued"');
+    await vi.waitFor(() => expect(stop).toHaveBeenCalledOnce());
+  });
+
   test('streams TTS playback completed-count progress in SSE snapshots', async () => {
     const now = Date.now();
     fake.seedState({

--- a/packages/compute-worker/tests/api/routes.test.ts
+++ b/packages/compute-worker/tests/api/routes.test.ts
@@ -5,6 +5,21 @@ import { FakeControlPlane } from '../fixtures/fake-control-plane';
 
 const AUTH = { authorization: 'Bearer test-token' };
 
+function snapshotSequence(body: string): Array<{ eventId: number; status: string }> {
+  return body.split('\n\n').flatMap((frame) => {
+    if (!frame.split('\n').includes('event: snapshot')) return [];
+    const id = frame.split('\n').find((line) => line.startsWith('id: '));
+    const data = frame.split('\n').find((line) => line.startsWith('data: '));
+    if (!id || !data) return [];
+    const payload = JSON.parse(data.slice('data: '.length)) as {
+      snapshot?: { status?: unknown };
+    };
+    return typeof payload.snapshot?.status === 'string'
+      ? [{ eventId: Number(id.slice('id: '.length)), status: payload.snapshot.status }]
+      : [];
+  });
+}
+
 describe('compute worker API routes', () => {
   let fake: FakeControlPlane;
   let runtime: Awaited<ReturnType<typeof createComputeWorkerApp>>;
@@ -421,9 +436,10 @@ describe('compute worker API routes', () => {
       return stop;
     });
     const stream = await runtime.app.inject({ method: 'GET', url: '/v1/operations/op-gap/events', headers: AUTH });
-    expect(stream.body).toContain('"status":"running"');
-    expect(stream.body).toContain('"status":"succeeded"');
-    expect(stream.body).not.toContain('"status":"queued"');
+    expect(snapshotSequence(stream.body)).toEqual([
+      { eventId: 0, status: 'running' },
+      { eventId: 2, status: 'succeeded' },
+    ]);
     await vi.waitFor(() => expect(stop).toHaveBeenCalledOnce());
   });
 
@@ -445,9 +461,10 @@ describe('compute worker API routes', () => {
     const stream = await runtime.app.inject({
       method: 'GET', url: '/v1/operations/op-equal-time/events', headers: AUTH,
     });
-    expect(stream.body).toContain('"status":"running"');
-    expect(stream.body).toContain('"status":"succeeded"');
-    expect(stream.body).not.toContain('"status":"queued"');
+    expect(snapshotSequence(stream.body)).toEqual([
+      { eventId: 0, status: 'running' },
+      { eventId: 2, status: 'succeeded' },
+    ]);
     await vi.waitFor(() => expect(stop).toHaveBeenCalledOnce());
   });
 

--- a/packages/compute-worker/tests/unit/jetstream-adapters.test.ts
+++ b/packages/compute-worker/tests/unit/jetstream-adapters.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { DeliverPolicy } from '@nats-io/jetstream';
 import { OperationOrchestrator } from '../../src/operations/service';
 import type { WorkerOperationRequest } from '../../src/operations/contracts';
 import {
@@ -88,6 +89,65 @@ function buildPdfRequest(opKey: string): WorkerOperationRequest {
 }
 
 describe('jetstream adapters', () => {
+  test('replays a completion published between the initial state read and subscription', async () => {
+    let policy: unknown;
+    const terminal = { opId: 'op-gap', status: 'succeeded', updatedAt: 2 };
+    const onEvent = vi.fn();
+    const add = vi.fn(async (_stream: string, config: { deliver_policy: unknown }) => {
+      policy = config.deliver_policy;
+    });
+    const events = new JetStreamOperationEventStream({
+      getJsm: async () => ({ consumers: { add, delete: async () => true } }) as never,
+      getJs: async () => ({ consumers: { get: async () => ({ consume: async () => ({
+        close: async () => undefined,
+        async *[Symbol.asyncIterator]() {
+          // This event already exists when the consumer is created, so a
+          // new-only subscription cannot see it and would remain pending.
+          if (policy === DeliverPolicy.Last) {
+            yield { seq: 9, data: new TextEncoder().encode(JSON.stringify(terminal)) };
+          }
+        },
+      }) }) } }) as never,
+      eventsStreamName: 'events',
+    });
+    const stop = await events.subscribe({ opId: 'op-gap', onEvent });
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledWith({ eventId: 9, snapshot: terminal }));
+    expect(add).toHaveBeenCalledWith('events', expect.objectContaining({
+      deliver_policy: DeliverPolicy.Last, filter_subject: opEventsSubject('op-gap'),
+    }));
+    stop();
+    await events.subscribe({ opId: 'op-gap', sinceEventId: 9, onEvent });
+    expect(add).toHaveBeenLastCalledWith('events', expect.objectContaining({
+      deliver_policy: DeliverPolicy.StartSequence, opt_start_seq: 10,
+    }));
+  });
+
+  test('reads historical operation states with bounded parallelism', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let active = 0;
+    let maximum = 0;
+    class SlowKvStore extends FakeKvStore {
+      override async get(key: string) {
+        active++;
+        maximum = Math.max(maximum, active);
+        await gate;
+        active--;
+        return super.get(key);
+      }
+    }
+    const kv = new SlowKvStore();
+    for (let i = 0; i < 40; i++) {
+      await kv.put(opStateKvKey(`op-${i}`), new TextEncoder().encode(JSON.stringify({ opId: `op-${i}` })));
+    }
+    const store = new JetStreamOperationStateStore({ getKv: async () => kv });
+    const read = store.listOpStates();
+    await vi.waitFor(() => expect(active).toBe(32));
+    release();
+    expect(await read).toHaveLength(40);
+    expect(maximum).toBe(32);
+  });
+
   test('state store compareAndSet enforces create/update semantics', async () => {
     const kv = new FakeKvStore();
     const store = new JetStreamOperationStateStore({ getKv: async () => kv });

--- a/packages/compute-worker/tests/unit/playback-job-cache-discovery.test.ts
+++ b/packages/compute-worker/tests/unit/playback-job-cache-discovery.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createTtsPlaybackHandler } from '../../src/jobs/playback/playback-job';
+import { resolveAndPersistTtsPlaybackPlan } from '../../src/jobs/playback/plan';
+import { generateExplicitTtsPlaybackSegments } from '../../src/jobs/playback/segment-generation';
+
+vi.mock('../../src/jobs/playback/plan', () => ({ resolveAndPersistTtsPlaybackPlan: vi.fn() }));
+vi.mock('../../src/jobs/playback/segment-generation', () => ({ generateExplicitTtsPlaybackSegments: vi.fn() }));
+
+describe('playback job cache discovery', () => {
+  test('starts a sparse long book without probing every ungenerated segment', async () => {
+    const plannedSegments = Array.from({ length: 10_000 }, (_, ordinal) => ({ ordinal, text: 'A sentence.' }));
+    vi.mocked(resolveAndPersistTtsPlaybackPlan).mockResolvedValue({
+      planObjectKey: 'plan', plannedSegments, startOrdinal: 8_000,
+    } as never);
+    const session = {
+      sessionId: 'session', status: 'running', generationRunId: 'run', playbackActive: true,
+      cursorOrdinal: 8_000, generationStartOrdinal: 8_000, expiresAt: Date.now() + 60_000,
+    };
+    const sidecars = new Map([
+      [2, { ordinal: 2, status: 'completed', audioKey: 'audio/2', cacheEpoch: 3 }],
+      [7, { ordinal: 7, status: 'completed', audioKey: 'old/7', cacheEpoch: 2 }],
+      [8_000, { ordinal: 8_000, status: 'generating', cacheEpoch: 3 }],
+      [20_000, { ordinal: 20_000, status: 'completed', audioKey: 'outside-plan', cacheEpoch: 3 }],
+    ]);
+    const readSegmentMetadata = vi.fn(async ({ ordinal }: { ordinal: number }) => sidecars.get(ordinal) ?? null);
+    const listSegmentOrdinals = vi.fn(async () => [...sidecars.keys()]);
+    const onProgress = vi.fn();
+    const run = createTtsPlaybackHandler({
+      storage: {}, s3Prefix: 'test', ttsPlaybackSegmentTimeoutMs: 30_000,
+      playbackStorage: {
+        artifacts: { getScopeEpoch: async () => 3, listSegmentOrdinals, readSegmentMetadata },
+        sessions: {
+          getSession: async () => session,
+          patchSessionIfGenerationRun: async () => session,
+          watchGenerationInvalidation: async () => () => undefined,
+        },
+      },
+    } as never);
+    await run({
+      userId: 'user', storageUserId: 'user', documentId: 'document', documentVersion: 1,
+      readerType: 'epub', settingsHash: 'settings', settingsJson: {}, planning: {},
+      sessionId: 'session', generationRunId: 'run', planObjectKey: 'plan',
+    }, 0, { onProgress });
+    expect(listSegmentOrdinals).toHaveBeenCalledTimes(1);
+    expect(readSegmentMetadata.mock.calls.map(([scope]) => scope.ordinal)).toEqual([2, 7, 8_000]);
+    expect(onProgress).toHaveBeenCalledWith(expect.objectContaining({ completedCount: 1, completedThroughOrdinal: 2 }));
+    expect(generateExplicitTtsPlaybackSegments).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/compute-worker/tests/unit/playback-job-cache-discovery.test.ts
+++ b/packages/compute-worker/tests/unit/playback-job-cache-discovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createTtsPlaybackHandler } from '../../src/jobs/playback/playback-job';
 import { resolveAndPersistTtsPlaybackPlan } from '../../src/jobs/playback/plan';
 import { generateExplicitTtsPlaybackSegments } from '../../src/jobs/playback/segment-generation';
@@ -7,6 +7,8 @@ vi.mock('../../src/jobs/playback/plan', () => ({ resolveAndPersistTtsPlaybackPla
 vi.mock('../../src/jobs/playback/segment-generation', () => ({ generateExplicitTtsPlaybackSegments: vi.fn() }));
 
 describe('playback job cache discovery', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
   test('starts a sparse long book without probing every ungenerated segment', async () => {
     const plannedSegments = Array.from({ length: 10_000 }, (_, ordinal) => ({ ordinal, text: 'A sentence.' }));
     vi.mocked(resolveAndPersistTtsPlaybackPlan).mockResolvedValue({
@@ -45,5 +47,40 @@ describe('playback job cache discovery', () => {
     expect(readSegmentMetadata.mock.calls.map(([scope]) => scope.ordinal)).toEqual([2, 7, 8_000]);
     expect(onProgress).toHaveBeenCalledWith(expect.objectContaining({ completedCount: 1, completedThroughOrdinal: 2 }));
     expect(generateExplicitTtsPlaybackSegments).toHaveBeenCalledTimes(1);
+  });
+
+  test('continues with per-segment cache checks when catalogue discovery is unavailable', async () => {
+    vi.mocked(resolveAndPersistTtsPlaybackPlan).mockResolvedValue({
+      planObjectKey: 'plan', plannedSegments: [{ ordinal: 8, text: 'A sentence.' }], startOrdinal: 8,
+    } as never);
+    const session = {
+      sessionId: 'session', status: 'running', generationRunId: 'run', playbackActive: true,
+      cursorOrdinal: 8, generationStartOrdinal: 8, expiresAt: Date.now() + 60_000,
+    };
+    const logger = { warn: vi.fn() };
+    const run = createTtsPlaybackHandler({
+      storage: {}, s3Prefix: 'test', ttsPlaybackSegmentTimeoutMs: 30_000, logger,
+      playbackStorage: {
+        artifacts: {
+          getScopeEpoch: async () => 0,
+          listSegmentOrdinals: async () => { throw new Error('catalogue unavailable'); },
+          readSegmentMetadata: async () => null,
+        },
+        sessions: {
+          getSession: async () => session,
+          patchSessionIfGenerationRun: async () => session,
+          watchGenerationInvalidation: async () => () => undefined,
+        },
+      },
+    } as never);
+    await expect(run({
+      userId: 'user', storageUserId: 'user', documentId: 'document', documentVersion: 1,
+      readerType: 'epub', settingsHash: 'settings', settingsJson: {}, planning: {},
+      sessionId: 'session', generationRunId: 'run', planObjectKey: 'plan',
+    }, 0)).resolves.toMatchObject({ sessionId: 'session' });
+    expect(generateExplicitTtsPlaybackSegments).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session', error: 'catalogue unavailable',
+    }), 'tts.playback.cache_catalogue_read_failed');
   });
 });

--- a/packages/compute-worker/tests/unit/playback-operation-invalidation.test.ts
+++ b/packages/compute-worker/tests/unit/playback-operation-invalidation.test.ts
@@ -60,7 +60,15 @@ describe('playback operation invalidation', () => {
         planSignature: 'signature-2',
       }),
     });
-    const rows = [live, plan, unrelated];
+    const unrelatedLive = state({
+      opId: 'unrelated-live', kind: 'tts_playback',
+      opKey: buildTtsPlaybackOperationKey({
+        sessionId: 'other-session', storageUserId: scope.storageUserId,
+        documentId: 'other-document', documentVersion: scope.documentVersion,
+        readerType: 'pdf', settingsHash: scope.settingsHash, planObjectKey: 'other-plan.json',
+      }),
+    });
+    const rows = [live, plan, unrelated, unrelatedLive];
     type InvalidationInput = Parameters<NonNullable<OrchestratorLike['markFailedIfUnchanged']>>[0];
     const markFailedIfUnchanged = vi.fn(async (_input: InvalidationInput) => ({ status: 'failed' }));
     const operationStateStore = {
@@ -71,9 +79,7 @@ describe('playback operation invalidation', () => {
       },
     } as OperationStateStoreLike;
     const orchestrator = { markFailedIfUnchanged } as unknown as OrchestratorLike;
-    const readSession = vi.fn(async (sessionId: string) => sessionId === 'session-1'
-      ? { storageUserId: scope.storageUserId }
-      : null);
+    const readSession = vi.fn(async () => ({ storageUserId: scope.storageUserId }));
 
     await expect(invalidatePlaybackOperationsForScope({
       scope,
@@ -82,8 +88,42 @@ describe('playback operation invalidation', () => {
       orchestrator,
       readSession: readSession as never,
     })).resolves.toBe(2);
-    expect(readSession).toHaveBeenCalledWith('session-1');
+    expect(readSession).toHaveBeenCalledExactlyOnceWith('session-1');
     expect(markFailedIfUnchanged).toHaveBeenCalledTimes(2);
-    expect(markFailedIfUnchanged.mock.calls.map(([call]) => call.current.opId)).toEqual(['live', 'plan']);
+    expect(markFailedIfUnchanged.mock.calls.map(([call]) => call.current.opId).sort()).toEqual(['live', 'plan']);
+  });
+
+  test('bounds concurrent invalidation reads and shares session ownership lookups', async () => {
+    const scope = { storageUserId: 'user-1', documentId: 'doc-1' };
+    const rows = Array.from({ length: 40 }, (_, i) => state({
+      opId: `op-${i}`, kind: 'tts_playback',
+      opKey: buildTtsPlaybackOperationKey({
+        ...scope, sessionId: 'session-1', documentVersion: 1, readerType: 'html',
+        settingsHash: 'settings', planObjectKey: 'plan', generationRunId: `run-${i}`,
+      }),
+    }));
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let active = 0;
+    let maximum = 0;
+    const getOpStateRecord = vi.fn(async (opId: string) => {
+      active++;
+      maximum = Math.max(active, maximum);
+      await gate;
+      active--;
+      return { state: rows.find((row) => row.opId === opId)!, revision: 1 };
+    });
+    const readSession = vi.fn(async () => ({ storageUserId: 'user-1' }));
+    const run = invalidatePlaybackOperationsForScope({
+      scope, now: 100,
+      operationStateStore: { listOpStates: async () => rows, getOpStateRecord } as unknown as OperationStateStoreLike,
+      orchestrator: { markFailedIfUnchanged: async () => ({ status: 'failed' }) } as unknown as OrchestratorLike,
+      readSession: readSession as never,
+    });
+    await vi.waitFor(() => expect(getOpStateRecord).toHaveBeenCalledTimes(16));
+    release();
+    expect(await run).toBe(40);
+    expect(maximum).toBe(16);
+    expect(readSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/compute-worker/tests/unit/playback-operation-invalidation.test.ts
+++ b/packages/compute-worker/tests/unit/playback-operation-invalidation.test.ts
@@ -126,4 +126,27 @@ describe('playback operation invalidation', () => {
     expect(maximum).toBe(16);
     expect(readSession).toHaveBeenCalledTimes(1);
   });
+
+  test('reports a session ownership read failure instead of claiming cleanup succeeded', async () => {
+    const scope = { storageUserId: 'user-1', documentId: 'doc-1' };
+    const live = state({
+      opId: 'live', kind: 'tts_playback',
+      opKey: buildTtsPlaybackOperationKey({
+        ...scope, sessionId: 'session-1', documentVersion: 1, readerType: 'epub',
+        settingsHash: 'settings', planObjectKey: 'plan', generationRunId: 'run-1',
+      }),
+    });
+    const markFailedIfUnchanged = vi.fn();
+    await expect(invalidatePlaybackOperationsForScope({
+      scope,
+      now: 100,
+      operationStateStore: {
+        listOpStates: async () => [live],
+        getOpStateRecord: async () => ({ state: live, revision: 1 }),
+      } as unknown as OperationStateStoreLike,
+      orchestrator: { markFailedIfUnchanged } as unknown as OrchestratorLike,
+      readSession: async () => { throw new Error('session store unavailable'); },
+    })).rejects.toThrow('session store unavailable');
+    expect(markFailedIfUnchanged).not.toHaveBeenCalled();
+  });
 });

--- a/packages/compute-worker/tests/unit/playback-session-controller.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
+import Fastify from 'fastify';
 
 import { createPlaybackSessionController } from '../../src/api/playback/session-controller';
 import type {
@@ -7,6 +8,8 @@ import type {
 } from '../../src/api/playback/session-read-model';
 import type { ComputeWorkerRouteContext } from '../../src/api/route-context';
 import type { TtsPlaybackStorage } from '../../src/playback/storage';
+import { resolveTtsPlaybackSessionInstanceId } from '../../src/playback/storage';
+import { registerPlaybackSessionRoutes } from '../../src/api/routes/playback/sessions';
 
 function playbackSession(overrides: Partial<PlaybackSessionRow> = {}): PlaybackSessionRow {
   return {
@@ -79,7 +82,7 @@ function createFixture(
         if (next.expiresAt <= session.expiresAt) {
           return (next.generationRunId ?? null) === (session.generationRunId ?? null);
         }
-        session = next;
+        session = { ...next, sessionInstanceId: resolveTtsPlaybackSessionInstanceId(next) };
         return true;
       },
       patchSession,
@@ -113,10 +116,56 @@ function createFixture(
     enqueueOrReuse,
     updateCursor,
     currentSession: () => session,
+    context,
+    readModel,
   };
 }
 
 describe('playback session continuation controller', () => {
+  test('does not reuse a completed partial run when resuming at the same cursor', async () => {
+    const fixture = createFixture(playbackSession({ generationRunId: 'active:12' }));
+    await fixture.controller.enqueueContinuationIfNeeded(fixture.currentSession(), Date.now(), 'cursor');
+    const first = fixture.enqueueOrReuse.mock.calls[0][0].opKey;
+    const instance = fixture.currentSession().sessionInstanceId;
+    await fixture.controller.enqueueContinuationIfNeeded(fixture.currentSession(), Date.now(), 'cursor');
+    expect(fixture.enqueueOrReuse.mock.calls[1][0].opKey).not.toBe(first);
+    expect(fixture.currentSession().sessionInstanceId).toBe(instance);
+    expect(fixture.currentSession().sessionId).toBe('session-1');
+  });
+
+  test('preparation queues nothing until activation and rejects a delayed old pause', async () => {
+    const fixture = createFixture(playbackSession({ expiresAt: 1 }));
+    const app = Fastify();
+    registerPlaybackSessionRoutes({ ...fixture.context, app } as ComputeWorkerRouteContext,
+      fixture.readModel, fixture.controller);
+    try {
+      const payload = {
+        sessionId: 'session-1', userId: 'user-1', storageUserId: 'storage-1',
+        documentId: 'a'.repeat(64), documentVersion: 1, readerType: 'epub',
+        settingsHash: 'settings-1', settingsJson: {}, planObjectKey: 'plans/session-1.json',
+        planning: { selectedOrdinal: 12 }, generationRunId: 'prepared:first', expiresAt: Date.now() + 60_000,
+      };
+      const prepared = await app.inject({ method: 'POST', url: '/v1/tts-playback/sessions/prepare', payload });
+      expect(prepared.statusCode).toBe(200);
+      expect(fixture.currentSession()).toMatchObject({ playbackActive: false, workerOpId: null });
+      await fixture.controller.updateCursor('session-1', 12, { ensureGeneration: true });
+      expect(fixture.enqueueOrReuse).not.toHaveBeenCalled();
+      const firstInstance = prepared.json().sessionInstanceId;
+      const activated = await app.inject({ method: 'PUT', url: '/v1/tts-playback/sessions/session-1/cursor',
+        payload: { ordinal: 12, playbackActive: true, sessionInstanceId: firstInstance } });
+      expect(activated.statusCode).toBe(200);
+      expect(activated.json().workerOpId).toBe('continuation-op');
+      expect(fixture.enqueueOrReuse).toHaveBeenCalledTimes(1);
+      await app.inject({ method: 'POST', url: '/v1/tts-playback/sessions/prepare',
+        payload: { ...payload, generationRunId: 'prepared:second', expiresAt: payload.expiresAt + 1 } });
+      const late = await app.inject({ method: 'PUT', url: '/v1/tts-playback/sessions/session-1/cursor',
+        payload: { ordinal: 99, playbackActive: true, sessionInstanceId: firstInstance } });
+      expect(late.statusCode).toBe(409);
+      expect(fixture.currentSession()).toMatchObject({ playbackActive: false, cursorOrdinal: 12 });
+      expect(fixture.enqueueOrReuse).toHaveBeenCalledTimes(1);
+    } finally { await app.close(); }
+  });
+
   test('does not enqueue cursor or stream continuations while explicitly paused', async () => {
     const fixture = createFixture(playbackSession({ playbackActive: false }));
 
@@ -165,7 +214,7 @@ describe('playback session continuation controller', () => {
     expect(firstRequest?.opKey).toBe(secondRequest?.opKey);
     expect(fixture.currentSession()).toMatchObject({
       playbackActive: true,
-      generationRunId: 'active:12',
+      generationRunId: expect.stringMatching(/^active:12:/),
     });
   });
 
@@ -222,7 +271,7 @@ describe('playback session continuation controller', () => {
     expect(fixture.enqueueOrReuse).toHaveBeenCalledTimes(1);
     expect(fixture.currentSession()).toMatchObject({
       cursorOrdinal: 24,
-      generationRunId: 'active:24',
+      generationRunId: expect.stringMatching(/^active:24:/),
     });
   });
 
@@ -241,7 +290,7 @@ describe('playback session continuation controller', () => {
 
     expect(fixture.enqueueOrReuse).toHaveBeenCalledTimes(1);
     expect(fixture.currentSession()).toMatchObject({
-      generationRunId: 'active:15',
+      generationRunId: expect.stringMatching(/^active:15:/),
       generationSatisfiedFromOrdinal: null,
       generationSatisfiedThroughOrdinal: null,
     });

--- a/packages/compute-worker/tests/unit/playback-session-controller.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-controller.test.ts
@@ -91,6 +91,7 @@ function createFixture(
     },
     artifacts: {
       sidecarKey() { return ''; },
+      async listSegmentOrdinals() { return []; },
       async putSegmentMetadata() { return ''; },
       async readSegmentMetadata() { return null; },
       async getScopeEpoch() { return 0; },

--- a/packages/compute-worker/tests/unit/playback-session-controller.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-controller.test.ts
@@ -70,8 +70,11 @@ function createFixture(
     _sessionId: string,
     expectedGenerationRunId: string | null,
     patch: Partial<PlaybackSessionRow>,
+    expectedSessionInstanceId?: string,
   ) => {
     if ((session.generationRunId ?? null) !== expectedGenerationRunId) return false;
+    if (expectedSessionInstanceId !== undefined
+      && resolveTtsPlaybackSessionInstanceId(session) !== expectedSessionInstanceId) return false;
     session = { ...session, ...patch };
     return true;
   });
@@ -116,6 +119,7 @@ function createFixture(
     enqueueOrReuse,
     updateCursor,
     currentSession: () => session,
+    replaceSession: (next: PlaybackSessionRow) => { session = next; },
     context,
     readModel,
   };
@@ -131,6 +135,17 @@ describe('playback session continuation controller', () => {
     expect(fixture.enqueueOrReuse.mock.calls[1][0].opKey).not.toBe(first);
     expect(fixture.currentSession().sessionInstanceId).toBe(instance);
     expect(fixture.currentSession().sessionId).toBe('session-1');
+  });
+
+  test('does not claim a replacement session that reuses the generation run id', async () => {
+    const fixture = createFixture(playbackSession());
+    const staleSession = fixture.currentSession();
+    fixture.replaceSession({ ...staleSession, sessionInstanceId: 'instance-2' });
+
+    await fixture.controller.enqueueContinuationIfNeeded(staleSession, Date.now(), 'cursor');
+
+    expect(fixture.enqueueOrReuse).not.toHaveBeenCalled();
+    expect(fixture.currentSession().sessionInstanceId).toBe('instance-2');
   });
 
   test('preparation queues nothing until activation and rejects a delayed old pause', async () => {
@@ -151,6 +166,11 @@ describe('playback session continuation controller', () => {
       await fixture.controller.updateCursor('session-1', 12, { ensureGeneration: true });
       expect(fixture.enqueueOrReuse).not.toHaveBeenCalled();
       const firstInstance = prepared.json().sessionInstanceId;
+      const missingInstance = await app.inject({
+        method: 'PUT', url: '/v1/tts-playback/sessions/session-1/cursor',
+        payload: { ordinal: 12, playbackActive: true },
+      });
+      expect(missingInstance.statusCode).toBe(400);
       const activated = await app.inject({ method: 'PUT', url: '/v1/tts-playback/sessions/session-1/cursor',
         payload: { ordinal: 12, playbackActive: true, sessionInstanceId: firstInstance } });
       expect(activated.statusCode).toBe(200);

--- a/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
@@ -218,6 +218,16 @@ describe('playback session read model', () => {
     expect(fixture.readSegmentMetadata).toHaveBeenCalledTimes(3);
   });
 
+  test('serves the in-process sidecar cache when catalogue discovery fails', async () => {
+    const fixture = createFixture();
+    fixture.sidecars.set(2, completedSidecar(2));
+    await expect(fixture.model.readSegmentState(session, 2))
+      .resolves.toMatchObject({ status: 'completed', ordinal: 2 });
+    fixture.listSegmentOrdinals.mockRejectedValueOnce(new Error('catalogue unavailable'));
+    await expect(fixture.model.readSegmentIndexRows(session))
+      .resolves.toMatchObject([{ ordinal: 2 }]);
+  });
+
   test('invalidates cached sidecars by exact scope and parsed plans by prefix', async () => {
     const fixture = createFixture();
     fixture.sidecars.set(0, completedSidecar(0));

--- a/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
@@ -60,8 +60,8 @@ function completedSidecar(ordinal: number, cacheEpoch = 0): TtsPlaybackSegmentMe
   };
 }
 
-function createFixture() {
-  const planSegments = Array.from({ length: 100 }, (_, ordinal) => ({
+function createFixture(planLength = 100) {
+  const planSegments = Array.from({ length: planLength }, (_, ordinal) => ({
     ordinal,
     text: `Segment ${ordinal}.`,
   }));
@@ -72,6 +72,7 @@ function createFixture() {
   let epoch = 0;
   const sidecars = new Map<number, TtsPlaybackSegmentMetadata>();
   const readSegmentMetadata = vi.fn(async ({ ordinal }: { ordinal: number }) => sidecars.get(ordinal) ?? null);
+  const listSegmentOrdinals = vi.fn(async () => [...sidecars.keys()].sort((a, b) => a - b));
   const storage = {
     async readObject(key: string) {
       const bytes = objects.get(key);
@@ -97,6 +98,7 @@ function createFixture() {
     },
     artifacts: {
       sidecarKey() { return ''; },
+      listSegmentOrdinals,
       async putSegmentMetadata() { return ''; },
       readSegmentMetadata,
       async getScopeEpoch() { return epoch; },
@@ -108,6 +110,7 @@ function createFixture() {
     objects,
     sidecars,
     readSegmentMetadata,
+    listSegmentOrdinals,
     setEpoch(value: number) { epoch = value; },
   };
 }
@@ -173,26 +176,46 @@ describe('playback session read model', () => {
     expect(fixture.readSegmentMetadata.mock.calls.map(([scope]) => scope.ordinal)).toEqual([40, 41, 42]);
   });
 
-  test('keeps a bounded whole-document cache view across cursor and chapter changes', async () => {
+  test('keeps all cached chapters visible without probing absent ordinals', async () => {
     const fixture = createFixture();
     fixture.sidecars.set(2, completedSidecar(2));
     fixture.sidecars.set(80, completedSidecar(80));
 
     const nearStartSession = { ...session, cursorOrdinal: 0 };
     await expect(fixture.model.readSegmentIndexRows(nearStartSession))
-      .resolves.toMatchObject([{ ordinal: 2 }]);
+      .resolves.toMatchObject([{ ordinal: 2 }, { ordinal: 80 }]);
     expect(fixture.readSegmentMetadata.mock.calls.map(([scope]) => scope.ordinal))
-      .toEqual(Array.from({ length: 65 }, (_, ordinal) => ordinal));
+      .toEqual([2, 80]);
 
-    // Discover a later cached chapter, then move the cursor back. The next
-    // whole-document read must retain both cached regions and extend its bounded
-    // scan from the highest discovered sidecar instead of hiding that cache.
+    // Moving back retains both cached regions without refetching exact timing.
     await expect(fixture.model.readSegmentState(session, 80))
       .resolves.toMatchObject({ status: 'completed', ordinal: 80 });
     fixture.readSegmentMetadata.mockClear();
     await expect(fixture.model.readSegmentIndexRows(nearStartSession))
       .resolves.toMatchObject([{ ordinal: 2 }, { ordinal: 80 }]);
-    expect(fixture.readSegmentMetadata.mock.calls.some(([scope]) => scope.ordinal === 99)).toBe(true);
+    expect(fixture.readSegmentMetadata).not.toHaveBeenCalled();
+  });
+
+  test('shares slow catalogue reads and discovers exact timing in a sparsely generated long book', async () => {
+    const fixture = createFixture(10_000);
+    const deepSession = { ...session, cursorOrdinal: 9_000 };
+    fixture.sidecars.set(2, completedSidecar(2));
+    fixture.sidecars.set(9_000, { ...completedSidecar(9_000), alignment: null });
+    let release!: (ordinals: number[]) => void;
+    const listed = new Promise<number[]>((resolve) => { release = resolve; });
+    fixture.listSegmentOrdinals.mockReturnValueOnce(listed);
+    const timeline = fixture.model.readSegmentIndexRows(deepSession);
+    const durations = fixture.model.listCompletedDurations(deepSession, 10_000);
+    await vi.waitFor(() => expect(fixture.listSegmentOrdinals).toHaveBeenCalledTimes(1));
+    release([2, 9_000]);
+    expect((await timeline).map((row) => row.alignmentSource)).toEqual(['exact', 'proportional']);
+    expect([...(await durations).keys()]).toEqual([2, 9_000]);
+    expect(fixture.readSegmentMetadata).toHaveBeenCalledTimes(2);
+
+    fixture.sidecars.set(9_000, completedSidecar(9_000));
+    const exact = await fixture.model.readSegmentIndexRows(deepSession);
+    expect(exact.at(-1)?.alignmentSource).toBe('exact');
+    expect(fixture.readSegmentMetadata).toHaveBeenCalledTimes(3);
   });
 
   test('invalidates cached sidecars by exact scope and parsed plans by prefix', async () => {

--- a/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
@@ -228,6 +228,30 @@ describe('playback session read model', () => {
       .resolves.toMatchObject([{ ordinal: 2 }]);
   });
 
+  test('does not reuse a pending scope collection after cache invalidation', async () => {
+    const fixture = createFixture();
+    fixture.sidecars.set(0, completedSidecar(0));
+    let release!: (ordinals: number[]) => void;
+    fixture.listSegmentOrdinals.mockReturnValueOnce(new Promise((resolve) => { release = resolve; }));
+    const staleRead = fixture.model.readSegmentIndexRows(session);
+    await vi.waitFor(() => expect(fixture.listSegmentOrdinals).toHaveBeenCalledTimes(1));
+
+    fixture.sidecars.clear();
+    fixture.sidecars.set(1, completedSidecar(1));
+    expect(fixture.model.invalidateSidecarsForScope({
+      storageUserId: session.storageUserId,
+      documentId: session.documentId,
+      documentVersion: session.documentVersion,
+      settingsHash: session.settingsHash,
+    })).toBe(1);
+
+    await expect(fixture.model.readSegmentIndexRows(session))
+      .resolves.toMatchObject([{ ordinal: 1 }]);
+    expect(fixture.listSegmentOrdinals).toHaveBeenCalledTimes(2);
+    release([0]);
+    await staleRead;
+  });
+
   test('invalidates cached sidecars by exact scope and parsed plans by prefix', async () => {
     const fixture = createFixture();
     fixture.sidecars.set(0, completedSidecar(0));

--- a/packages/compute-worker/tests/unit/playback-storage.test.ts
+++ b/packages/compute-worker/tests/unit/playback-storage.test.ts
@@ -194,6 +194,12 @@ describe('TTS playback storage', () => {
     });
 
     await store.patchSession('session-1', { status: 'running', updatedAt: 400 });
+    await store.patchSession('session-1', {
+      playbackActive: true, cursorOrdinal: 99, cursorUpdatedAt: 450, expiresAt: 9999,
+    }, 'replaced-instance');
+    expect(await store.getSession('session-1')).toMatchObject({
+      playbackActive: false, cursorOrdinal: 42, expiresAt: 1234,
+    });
     await store.updateCursor('session-1', 43, 'instance-1', 500);
     expect(await store.getSession('session-1')).toMatchObject({
       status: 'running',

--- a/packages/compute-worker/tests/unit/playback-storage.test.ts
+++ b/packages/compute-worker/tests/unit/playback-storage.test.ts
@@ -130,6 +130,17 @@ class WatchableMemoryKv extends MemoryKv {
 }
 
 describe('TTS playback storage', () => {
+  test('lists existing segment ordinals only within the exact artifact scope', async () => {
+    const storage = new MemoryStorage();
+    const artifacts = createTtsPlaybackSegmentArtifactStore({ storage, s3Prefix: 'openreader' });
+    const scope = { storageUserId: 'user-1', documentId: 'a'.repeat(64), documentVersion: 1, settingsHash: 'settings-1' };
+    await storage.putObject(artifacts.sidecarKey({ ...scope, ordinal: 9000 }), Buffer.from('{}'));
+    await storage.putObject(artifacts.sidecarKey({ ...scope, ordinal: 2 }), Buffer.from('{}'));
+    await storage.putObject(artifacts.sidecarKey({ ...scope, settingsHash: 'other-settings', ordinal: 3 }), Buffer.from('{}'));
+    await storage.putObject(artifacts.sidecarKey({ ...scope, ordinal: 4 }) + '.tmp', Buffer.from('{}'));
+    expect(await artifacts.listSegmentOrdinals(scope)).toEqual([2, 9000]);
+  });
+
   test('stores sessions and updates cursors in KV', async () => {
     const kv = new MemoryKv();
     const store = createTtsPlaybackKvStore({ getKv: async () => kv });

--- a/packages/compute-worker/tests/unit/playback-storage.test.ts
+++ b/packages/compute-worker/tests/unit/playback-storage.test.ts
@@ -464,6 +464,51 @@ describe('TTS playback storage', () => {
     });
   });
 
+  test('rejects a generation patch from a replaced session instance', async () => {
+    const kv = new MemoryKv();
+    const store = createTtsPlaybackKvStore({ getKv: async () => kv });
+    const initial = {
+      schemaVersion: 1 as const,
+      sessionId: 'session-instance-guard',
+      userId: 'user-1',
+      storageUserId: 'storage-1',
+      documentId: 'a'.repeat(64),
+      documentVersion: 1,
+      readerType: 'epub' as const,
+      status: 'running' as const,
+      settingsHash: 'settings-hash',
+      settingsJson: { voice: 'v' },
+      playbackActive: true,
+      generationRunId: 'shared-run',
+      sessionInstanceId: 'instance-old',
+      generationStartOrdinal: 10,
+      cursorOrdinal: 10,
+      cursorUpdatedAt: 100,
+      planObjectKey: 'plans/session-instance-guard.json',
+      expiresAt: 1234,
+      lastError: null,
+      updatedAt: 100,
+    };
+    await store.putSessionIfNewer(initial);
+    await store.putSessionIfNewer({
+      ...initial,
+      sessionInstanceId: 'instance-new',
+      expiresAt: 1235,
+      updatedAt: 101,
+    });
+
+    expect(await store.patchSessionIfGenerationRun(
+      initial.sessionId,
+      'shared-run',
+      { generationRunId: 'stale-claim' },
+      'instance-old',
+    )).toBe(false);
+    expect(await store.getSession(initial.sessionId)).toMatchObject({
+      sessionInstanceId: 'instance-new',
+      generationRunId: 'shared-run',
+    });
+  });
+
   test('does not let an older session request overwrite a newer overlapping request', async () => {
     class InterleavingKv extends MemoryKv {
       beforeNextUpdate: (() => Promise<void>) | null = null;

--- a/src/app/api/tts/segments/clear/route.ts
+++ b/src/app/api/tts/segments/clear/route.ts
@@ -6,6 +6,7 @@ import { errorResponse } from '@/lib/server/errors/next-response';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
 
 function parseBody(value: unknown): { documentId: string } | null {
   if (!value || typeof value !== 'object') return null;
@@ -37,7 +38,7 @@ export async function POST(request: NextRequest) {
       documentVersion: scope.documentVersion,
       readerType: scope.readerType,
       namespace: null,
-    });
+    }, { signal: AbortSignal.timeout(45_000) });
 
     return NextResponse.json({
       documentId: parsed.documentId,
@@ -47,6 +48,12 @@ export async function POST(request: NextRequest) {
       ...cleared,
     });
   } catch (error) {
+    if (error instanceof Error && error.name === 'TimeoutError') {
+      logger.warn({ event: 'tts.segments.clear_confirmation_timeout' }, 'Cache cleanup confirmation timed out');
+      return NextResponse.json({
+        error: 'Cleanup confirmation timed out. The cache may already be reset; cleanup may still be running. Reload the reader before trying playback again.',
+      }, { status: 504 });
+    }
     return errorResponse(error, {
       logger,
       event: 'tts.segments.clear_failed',

--- a/src/app/api/tts/stream/[sessionId]/cursor/route.ts
+++ b/src/app/api/tts/stream/[sessionId]/cursor/route.ts
@@ -10,14 +10,17 @@ import { errorResponse } from '@/lib/server/errors/next-response';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-function parseCursorUpdate(value: unknown): { ordinal: number; playbackActive?: boolean } | null {
+function parseCursorUpdate(value: unknown): { ordinal: number; playbackActive?: boolean; sessionInstanceId?: string } | null {
   if (!value || typeof value !== 'object') return null;
   const record = value as Record<string, unknown>;
   const ordinal = Number(record.ordinal);
   if (!Number.isFinite(ordinal)) return null;
   if (record.playbackActive !== undefined && typeof record.playbackActive !== 'boolean') return null;
+  if (record.sessionInstanceId !== undefined && (typeof record.sessionInstanceId !== 'string'
+    || !record.sessionInstanceId.trim() || record.sessionInstanceId.length > 256)) return null;
   return {
     ordinal: Math.max(0, Math.floor(ordinal)),
+    ...(typeof record.sessionInstanceId === 'string' ? { sessionInstanceId: record.sessionInstanceId } : {}),
     ...(typeof record.playbackActive === 'boolean' ? { playbackActive: record.playbackActive } : {}),
   };
 }
@@ -48,8 +51,9 @@ export async function POST(
 
     const now = Date.now();
     const expiresAt = now + TTS_PLAYBACK_SESSION_TTL_MS;
-    await getComputeWorkerClient().updateTtsPlaybackCursor({
+    const updated = await getComputeWorkerClient().updateTtsPlaybackCursor({
       sessionId: session.sessionId,
+      sessionInstanceId: cursorUpdate.sessionInstanceId,
       ordinal: cursorUpdate.ordinal,
       ...(cursorUpdate.playbackActive === undefined
         ? {}
@@ -59,6 +63,7 @@ export async function POST(
 
     return NextResponse.json({
       sessionId: session.sessionId,
+      workerOpId: updated.workerOpId,
       cursorOrdinal: cursorUpdate.ordinal,
       playbackActive: cursorUpdate.playbackActive ?? session.playbackActive ?? true,
       expiresAt,

--- a/src/app/api/tts/stream/[sessionId]/cursor/route.ts
+++ b/src/app/api/tts/stream/[sessionId]/cursor/route.ts
@@ -10,17 +10,17 @@ import { errorResponse } from '@/lib/server/errors/next-response';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-function parseCursorUpdate(value: unknown): { ordinal: number; playbackActive?: boolean; sessionInstanceId?: string } | null {
+function parseCursorUpdate(value: unknown): { ordinal: number; playbackActive?: boolean; sessionInstanceId: string } | null {
   if (!value || typeof value !== 'object') return null;
   const record = value as Record<string, unknown>;
   const ordinal = Number(record.ordinal);
   if (!Number.isFinite(ordinal)) return null;
   if (record.playbackActive !== undefined && typeof record.playbackActive !== 'boolean') return null;
-  if (record.sessionInstanceId !== undefined && (typeof record.sessionInstanceId !== 'string'
-    || !record.sessionInstanceId.trim() || record.sessionInstanceId.length > 256)) return null;
+  if (typeof record.sessionInstanceId !== 'string'
+    || !record.sessionInstanceId.trim() || record.sessionInstanceId.length > 256) return null;
   return {
     ordinal: Math.max(0, Math.floor(ordinal)),
-    ...(typeof record.sessionInstanceId === 'string' ? { sessionInstanceId: record.sessionInstanceId } : {}),
+    sessionInstanceId: record.sessionInstanceId,
     ...(typeof record.playbackActive === 'boolean' ? { playbackActive: record.playbackActive } : {}),
   };
 }
@@ -46,7 +46,7 @@ export async function POST(
 
     const cursorUpdate = parseCursorUpdate(await request.json().catch(() => null));
     if (cursorUpdate === null) {
-      return NextResponse.json({ error: 'Invalid cursor ordinal' }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid playback cursor update' }, { status: 400 });
     }
 
     const now = Date.now();

--- a/src/app/api/tts/stream/[sessionId]/events/route.ts
+++ b/src/app/api/tts/stream/[sessionId]/events/route.ts
@@ -39,6 +39,12 @@ export async function GET(
     if (!session.workerOpId) {
       return NextResponse.json({ error: 'Playback session has no worker operation yet' }, { status: 409 });
     }
+    const operationId = request.nextUrl.searchParams.get('operationId');
+    if (operationId && operationId !== session.workerOpId) {
+      // Event IDs belong to an operation. Never replay an old operation's
+      // Last-Event-ID against its successor; the cursor response retargets SSE.
+      return NextResponse.json({ error: 'Playback operation was replaced' }, { status: 409 });
+    }
 
     return await proxyOperationEvents({
       request,

--- a/src/app/api/tts/stream/[sessionId]/timeline/route.ts
+++ b/src/app/api/tts/stream/[sessionId]/timeline/route.ts
@@ -39,10 +39,8 @@ export async function GET(
       throw new Error('TTS playback timeline requires a canonical plan artifact');
     }
 
-    // No explicit window: the worker read model owns the documented bounded
-    // whole-document scan (0..max(highest cached, cursor)+64). Keeping that
-    // policy at the sidecar cache boundary prevents chapter changes from
-    // making already-generated audio disappear from the timeline.
+    // The worker lists existing sidecars across the document, keeping earlier
+    // cached chapters visible without probing every ungenerated ordinal.
     const segments = await listCompletedTtsPlaybackSegments(session);
     const completedSegments = new Map(segments.map((segment) => [segment.ordinal, {
       alignment: parseAlignment(segment.alignmentJson),

--- a/src/app/api/tts/stream/sessions/route.ts
+++ b/src/app/api/tts/stream/sessions/route.ts
@@ -111,7 +111,8 @@ export async function POST(request: NextRequest) {
       planObjectKey,
       purpose: parsed.generationExtent === 'document' ? 'export-document' : 'live',
     });
-    const operation = await new ComputeWorkerClient().createTtsPlaybackOperation({
+    const client = new ComputeWorkerClient();
+    const workerRequest = {
       sessionId,
       userId: scope.userId,
       storageUserId: scope.storageUserId,
@@ -128,14 +129,19 @@ export async function POST(request: NextRequest) {
       backgroundExtent,
       ...(parsed.generationExtent === 'document'
         ? {}
-        : { generationRunId: `initial:${selectedOrdinal}` }),
+        : { generationRunId: `prepared:${expiresAt}:${selectedOrdinal}` }),
       ...(parsed.generationExtent === 'document' ? { generationExtent: 'document' as const } : {}),
       planning,
-    }, { signal: request.signal });
+    };
+    const prepared = parsed.generationExtent === 'document' ? null
+      : await client.prepareTtsPlaybackSession(workerRequest, { signal: request.signal });
+    const operation = parsed.generationExtent === 'document'
+      ? await client.createTtsPlaybackOperation(workerRequest, { signal: request.signal }) : null;
 
     const responseBase = {
       sessionId,
       operation,
+      ...(prepared ? { sessionInstanceId: prepared.sessionInstanceId } : {}),
       timelineUrl: `/api/tts/stream/${encodeURIComponent(sessionId)}/timeline`,
       eventsUrl: `/api/tts/stream/${encodeURIComponent(sessionId)}/events`,
       seekLayoutUrl: parsed.planId

--- a/src/app/api/tts/stream/sessions/route.ts
+++ b/src/app/api/tts/stream/sessions/route.ts
@@ -112,6 +112,9 @@ export async function POST(request: NextRequest) {
       purpose: parsed.generationExtent === 'document' ? 'export-document' : 'live',
     });
     const client = new ComputeWorkerClient();
+    const preparedGenerationRunId = parsed.generationExtent === 'document'
+      ? null
+      : `prepared:${expiresAt}:${selectedOrdinal}`;
     const workerRequest = {
       sessionId,
       userId: scope.userId,
@@ -127,14 +130,15 @@ export async function POST(request: NextRequest) {
       // playback cursor; cursor heartbeats enqueue follow-up runs as needed.
       aheadWindow: TTS_PLAYBACK_AHEAD_WINDOW,
       backgroundExtent,
-      ...(parsed.generationExtent === 'document'
-        ? {}
-        : { generationRunId: `prepared:${expiresAt}:${selectedOrdinal}` }),
+      ...(preparedGenerationRunId === null ? {} : { generationRunId: preparedGenerationRunId }),
       ...(parsed.generationExtent === 'document' ? { generationExtent: 'document' as const } : {}),
       planning,
     };
-    const prepared = parsed.generationExtent === 'document' ? null
-      : await client.prepareTtsPlaybackSession(workerRequest, { signal: request.signal });
+    const prepared = preparedGenerationRunId === null ? null
+      : await client.prepareTtsPlaybackSession({
+        ...workerRequest,
+        generationRunId: preparedGenerationRunId,
+      }, { signal: request.signal });
     const operation = parsed.generationExtent === 'document'
       ? await client.createTtsPlaybackOperation(workerRequest, { signal: request.signal }) : null;
 

--- a/src/components/documents/DocumentSettings.tsx
+++ b/src/components/documents/DocumentSettings.tsx
@@ -137,6 +137,7 @@ export function DocumentSettings({ isOpen, setIsOpen, documentId, epub, html, la
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ documentId }),
+        signal: AbortSignal.timeout(60_000),
       });
       const payload = (await res.json().catch(() => null)) as ClearSegmentsPayload | null;
       if (!res.ok) {
@@ -160,7 +161,9 @@ export function DocumentSettings({ isOpen, setIsOpen, documentId, epub, html, la
       }
     },
     onError: (error) => {
-      toast.error(error instanceof Error ? error.message : 'Failed to clear cached audio');
+      toast.error(error instanceof Error && error.name === 'TimeoutError'
+        ? 'Cleanup confirmation timed out. The cache may already be reset. Reload the reader before trying playback again.'
+        : error instanceof Error ? error.message : 'Failed to clear cached audio');
     },
   });
   const { mutate: clearSegments, isPending: isClearingSegments } = clearSegmentsMutation;

--- a/src/components/player/TTSPlayer.tsx
+++ b/src/components/player/TTSPlayer.tsx
@@ -145,11 +145,14 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
             {isProcessing ? <LoadingSpinner /> : <SkipBackwardIcon className="w-5 h-5" />}
           </IconButton>
 
+          {/* Loading is cancelable through this same control. Keep it focusable
+              when cancellation flips intent back to Play, even if an older async
+              render has not cleared its processing flag yet. */}
           <IconButton
             onClick={togglePlay}
             aria-label={playbackControl.ariaLabel}
             aria-busy={playbackControl.isPending}
-            disabled={!isPlaying && (!isPlaybackReady || isProcessing || !hasReadableContent)}
+            disabled={!isPlaying && (!isPlaybackReady || !hasReadableContent)}
             className="relative"
           >
             {!hasReadableContent

--- a/src/hooks/audio/usePlaybackForegroundSync.ts
+++ b/src/hooks/audio/usePlaybackForegroundSync.ts
@@ -12,6 +12,7 @@ import {
 import type { TTSRequestHeaders } from '@/types/client';
 import { TTS_PLAYBACK_CURSOR_HEARTBEAT_MS } from '@/types/tts';
 import type { PlaybackSessionState } from '@/hooks/audio/usePlaybackProjection';
+import { createCoalescedPlaybackRefresh } from '@/lib/client/tts/playback-refresh';
 
 type UsePlaybackForegroundSyncInput = {
   playbackCursorOrdinalRef: MutableRefObject<number | null>;
@@ -36,6 +37,7 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
   const playbackEventsUnsubRef = useRef<(() => void) | null>(null);
   const playbackCursorIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const playbackActivityWriteRef = useRef<Promise<void>>(Promise.resolve());
+  const playbackRefreshRef = useRef<ReturnType<typeof createCoalescedPlaybackRefresh> | null>(null);
 
   const setWorkerPlaybackActive = useCallback((playbackActive: boolean) => {
     const session = playbackSessionRef.current;
@@ -53,6 +55,8 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
 
   const stopPlaybackForegroundSync = useCallback(() => {
     toast.dismiss(MODEL_DOWNLOAD_TOAST_ID);
+    playbackRefreshRef.current?.stop();
+    playbackRefreshRef.current = null;
     if (playbackCursorIntervalRef.current) {
       clearInterval(playbackCursorIntervalRef.current);
       playbackCursorIntervalRef.current = null;
@@ -72,7 +76,21 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
     if (!activeSession) return;
 
     stopPlaybackForegroundSync();
-    void refreshPlaybackTimeline(activeSession.timelineUrl).catch(() => undefined);
+    const refresh = createCoalescedPlaybackRefresh(async (signal) => {
+      if (runId !== playbackRunIdRef.current || playbackSessionRef.current !== activeSession) return;
+      const readSignal = AbortSignal.any([signal, AbortSignal.timeout(30_000)]);
+      await Promise.allSettled([
+        refreshPlaybackTimeline(activeSession.timelineUrl, readSignal),
+        activeSession.seekLayoutUrl
+          ? getTtsPlaybackSeekLayout(activeSession.seekLayoutUrl, readSignal).then((layout) => {
+            if (!readSignal.aborted && runId === playbackRunIdRef.current
+              && playbackSessionRef.current === activeSession) setPlaybackSeekLayout(layout);
+          })
+          : Promise.resolve(),
+      ]);
+    });
+    playbackRefreshRef.current = refresh;
+    refresh.request();
     playbackEventsUnsubRef.current = subscribeTtsPlaybackEvents(activeSession.sessionId, {
       onSnapshot: (snapshot) => {
         if (runId !== playbackRunIdRef.current) return;
@@ -96,16 +114,7 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
           return;
         }
         toast.dismiss(MODEL_DOWNLOAD_TOAST_ID);
-        const currentSession = playbackSessionRef.current;
-        if (!currentSession) return;
-        void refreshPlaybackTimeline(currentSession.timelineUrl).catch(() => undefined);
-        if (currentSession.seekLayoutUrl) {
-          void getTtsPlaybackSeekLayout(currentSession.seekLayoutUrl)
-            .then((layout) => {
-              if (runId === playbackRunIdRef.current) setPlaybackSeekLayout(layout);
-            })
-            .catch(() => undefined);
-        }
+        refresh.request();
       },
     });
 

--- a/src/hooks/audio/usePlaybackForegroundSync.ts
+++ b/src/hooks/audio/usePlaybackForegroundSync.ts
@@ -8,11 +8,12 @@ import {
   postTtsPlaybackCursor,
   subscribeTtsPlaybackEvents,
   type TtsPlaybackSeekLayout,
+  type TtsPlaybackEventSnapshot,
 } from '@/lib/client/api/tts';
 import type { TTSRequestHeaders } from '@/types/client';
 import { TTS_PLAYBACK_CURSOR_HEARTBEAT_MS } from '@/types/tts';
 import type { PlaybackSessionState } from '@/hooks/audio/usePlaybackProjection';
-import { createCoalescedPlaybackRefresh } from '@/lib/client/tts/playback-refresh';
+import { createCoalescedPlaybackRefresh, createPlaybackOperationSubscription } from '@/lib/client/tts/playback-refresh';
 
 type UsePlaybackForegroundSyncInput = {
   playbackCursorOrdinalRef: MutableRefObject<number | null>;
@@ -39,18 +40,22 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
   const playbackActivityWriteRef = useRef<Promise<void>>(Promise.resolve());
   const playbackRefreshRef = useRef<ReturnType<typeof createCoalescedPlaybackRefresh> | null>(null);
 
-  const setWorkerPlaybackActive = useCallback((playbackActive: boolean) => {
+  const setWorkerPlaybackActive = useCallback((playbackActive: boolean, requireAcknowledgement = false) => {
     const session = playbackSessionRef.current;
     const headers = playbackRequestHeadersRef.current;
     const ordinal = playbackCursorOrdinalRef.current;
-    if (!session || !headers || ordinal == null) return;
+    if (!session || !headers || ordinal == null) return Promise.resolve();
     // Serialize fast pause/resume writes so stale intent cannot arrive last.
-    playbackActivityWriteRef.current = playbackActivityWriteRef.current.then(() => (
-      postTtsPlaybackCursor(session.sessionId, Math.max(0, ordinal), headers, {
+    const write = playbackActivityWriteRef.current.then(async () => {
+      await postTtsPlaybackCursor(session.sessionId, Math.max(0, ordinal), headers, {
         playbackActive,
+        sessionInstanceId: session.sessionInstanceId,
+        requireAcknowledgement,
         keepalive: !playbackActive,
-      })
-    ));
+      });
+    });
+    playbackActivityWriteRef.current = write.catch(() => undefined);
+    return write;
   }, [playbackCursorOrdinalRef, playbackRequestHeadersRef, playbackSessionRef]);
 
   const stopPlaybackForegroundSync = useCallback(() => {
@@ -91,7 +96,8 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
     });
     playbackRefreshRef.current = refresh;
     refresh.request();
-    playbackEventsUnsubRef.current = subscribeTtsPlaybackEvents(activeSession.sessionId, {
+    const events = createPlaybackOperationSubscription<TtsPlaybackEventSnapshot>({
+      subscribe: (operationId, onSnapshot) => subscribeTtsPlaybackEvents(activeSession.sessionId, { onSnapshot }, operationId),
       onSnapshot: (snapshot) => {
         if (runId !== playbackRunIdRef.current) return;
         if (snapshot.status === 'failed') {
@@ -117,14 +123,27 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
         refresh.request();
       },
     });
+    playbackEventsUnsubRef.current = events.stop;
 
-    const writeCursor = () => {
+    let writingCursor = false;
+    const writeCursor = async () => {
+      if (writingCursor) return;
       const currentSession = playbackSessionRef.current;
       if (!currentSession) return;
       const cursorOrdinal = playbackCursorOrdinalRef.current;
       if (cursorOrdinal == null) return;
       const cursor = Math.max(0, cursorOrdinal);
-      void postTtsPlaybackCursor(currentSession.sessionId, cursor, headers);
+      writingCursor = true;
+      try {
+        const updated = await postTtsPlaybackCursor(currentSession.sessionId, cursor, headers, {
+          sessionInstanceId: currentSession.sessionInstanceId,
+        });
+        if (updated && runId === playbackRunIdRef.current && playbackSessionRef.current === activeSession) {
+          events.update(updated.workerOpId);
+        }
+      } finally {
+        writingCursor = false;
+      }
     };
     writeCursor();
     playbackCursorIntervalRef.current = setInterval(() => {

--- a/src/hooks/audio/usePlaybackMediaResume.ts
+++ b/src/hooks/audio/usePlaybackMediaResume.ts
@@ -1,117 +1,47 @@
 'use client';
 
 import { useCallback, type MutableRefObject } from 'react';
-
 import { resumePlaybackMedia } from '@/lib/client/tts/playback-control';
 import type { TTSRequestHeaders } from '@/types/client';
 import type { TtsPlaybackPhase } from '@/types/tts';
-import type { PlaybackSessionState } from '@/hooks/audio/usePlaybackProjection';
 
-type UsePlaybackMediaResumeInput = {
+export function usePlaybackMediaResume(input: {
   audioSpeed: number;
   isPlayingRef: MutableRefObject<boolean>;
-  playbackActiveRef: MutableRefObject<boolean>;
   playbackInFlightRef: MutableRefObject<boolean>;
   playbackRequestHeadersRef: MutableRefObject<TTSRequestHeaders | null>;
-  playbackResumeRunIdRef: MutableRefObject<number | null>;
   playbackRunIdRef: MutableRefObject<number>;
-  playbackSessionRef: MutableRefObject<PlaybackSessionState | null>;
-  cancelSeekResync: () => void;
-  invalidatePlaybackRun: () => void;
-  reconnectPlaybackStream: () => void;
   setIsPlaying: (value: boolean) => void;
   setIsProcessing: (value: boolean) => void;
   setPlaybackPhase: (phase: TtsPlaybackPhase) => void;
   setWorkerPlaybackActive: (active: boolean) => void;
   startPlaybackForegroundSync: (runId: number, headers: TTSRequestHeaders) => void;
-  stopPlaybackForegroundSync: () => void;
-  stopPlaybackProjectionLoop: () => void;
-};
-
-export function usePlaybackMediaResume(input: UsePlaybackMediaResumeInput) {
+  checkRecovery: () => void;
+}) {
   const {
-    audioSpeed,
-    isPlayingRef,
-    playbackActiveRef,
-    playbackInFlightRef,
-    playbackRequestHeadersRef,
-    playbackResumeRunIdRef,
-    playbackRunIdRef,
-    playbackSessionRef,
-    cancelSeekResync,
-    invalidatePlaybackRun,
-    reconnectPlaybackStream,
-    setIsPlaying,
-    setIsProcessing,
-    setPlaybackPhase,
-    setWorkerPlaybackActive,
-    startPlaybackForegroundSync,
-    stopPlaybackForegroundSync,
-    stopPlaybackProjectionLoop,
+    audioSpeed, isPlayingRef, playbackInFlightRef, playbackRequestHeadersRef,
+    playbackRunIdRef, setIsPlaying, setIsProcessing, setPlaybackPhase,
+    setWorkerPlaybackActive, startPlaybackForegroundSync, checkRecovery,
   } = input;
-
   return useCallback((audio: HTMLAudioElement) => {
-    const resumeRunId = playbackRunIdRef.current;
-    const headers = playbackRequestHeadersRef.current;
+    const runId = playbackRunIdRef.current;
     setWorkerPlaybackActive(true);
-    if (headers) startPlaybackForegroundSync(resumeRunId, headers);
+    const headers = playbackRequestHeadersRef.current;
+    if (headers) startPlaybackForegroundSync(runId, headers);
     audio.playbackRate = audioSpeed;
     playbackInFlightRef.current = true;
     setPlaybackPhase('buffering');
     setIsProcessing(true);
     isPlayingRef.current = true;
     setIsPlaying(true);
-    playbackResumeRunIdRef.current = resumeRunId;
-
-    void resumePlaybackMedia(
-      () => audio.play(),
-      () => resumeRunId === playbackRunIdRef.current && isPlayingRef.current,
-    ).then((result) => {
-      if (playbackResumeRunIdRef.current === resumeRunId) {
-        playbackResumeRunIdRef.current = null;
-      }
-      if (result.status !== 'stale') return;
-
-      console.warn('TTS media stream became stale; reconnecting from the current cursor:', result.error);
-      setWorkerPlaybackActive(false);
-      invalidatePlaybackRun();
-      cancelSeekResync();
-      stopPlaybackProjectionLoop();
-      stopPlaybackForegroundSync();
-      playbackActiveRef.current = false;
-      playbackSessionRef.current = null;
-      playbackRequestHeadersRef.current = null;
-      try {
-        audio.onerror = null;
-        audio.pause();
-        audio.removeAttribute('src');
-        audio.load();
-      } catch {
-        // A replacement stream does not depend on stale media teardown.
-      }
-      playbackInFlightRef.current = true;
-      setPlaybackPhase('planning');
-      setIsProcessing(true);
-      reconnectPlaybackStream();
-    });
+    // Recovery also watches play() promises that never settle. Neither path
+    // replaces the playback session or discards the generated-cache timeline.
+    void resumePlaybackMedia(() => audio.play(), () => (
+      runId === playbackRunIdRef.current && isPlayingRef.current
+    )).then((result) => { if (result.status === 'stale') checkRecovery(); });
   }, [
-    audioSpeed,
-    cancelSeekResync,
-    invalidatePlaybackRun,
-    isPlayingRef,
-    playbackActiveRef,
-    playbackInFlightRef,
-    playbackRequestHeadersRef,
-    playbackResumeRunIdRef,
-    playbackRunIdRef,
-    playbackSessionRef,
-    reconnectPlaybackStream,
-    setIsPlaying,
-    setIsProcessing,
-    setPlaybackPhase,
-    setWorkerPlaybackActive,
-    startPlaybackForegroundSync,
-    stopPlaybackForegroundSync,
-    stopPlaybackProjectionLoop,
+    audioSpeed, isPlayingRef, playbackInFlightRef, playbackRequestHeadersRef,
+    playbackRunIdRef, setIsPlaying, setIsProcessing, setPlaybackPhase,
+    setWorkerPlaybackActive, startPlaybackForegroundSync, checkRecovery,
   ]);
 }

--- a/src/hooks/audio/usePlaybackProjection.ts
+++ b/src/hooks/audio/usePlaybackProjection.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/client/tts/playback-grid';
 import { isPdfLocator, type TTSSegmentLocator } from '@/types/client';
 import type { TTSLocation, TTSSentenceAlignment } from '@/types/tts';
+import { createPlaybackTimelineLoader } from '@/lib/client/tts/playback-refresh';
 
 export type PlaybackSessionState = {
   sessionId: string;
@@ -77,6 +78,19 @@ export function usePlaybackProjection(input: UsePlaybackProjectionInput) {
     locatorKey: string;
   } | null>(null);
   const lastTimelineHealAtRef = useRef(0);
+  const timelineLoaderRef = useRef<ReturnType<typeof createPlaybackTimelineLoader<TtsPlaybackGrid>> | null>(null);
+  if (!timelineLoaderRef.current) {
+    timelineLoaderRef.current = createPlaybackTimelineLoader({
+      getRunId: () => playbackRunIdRef.current,
+      getSession: () => playbackSessionRef.current,
+      apply: (timeline) => { playbackTimelineRef.current = timeline; },
+      load: async (url, signal) => {
+        const response = await fetch(url, { cache: 'no-store', signal });
+        if (!response.ok) throw new Error(`Failed to load TTS playback timeline: ${response.status}`);
+        return normalizePlaybackGrid(await response.json());
+      },
+    });
+  }
 
   const publishPlaybackTimeSec = useCallback((value: number, options?: { force?: boolean }) => {
     const next = Math.max(0, Number.isFinite(value) ? value : 0);
@@ -114,13 +128,7 @@ export function usePlaybackProjection(input: UsePlaybackProjectionInput) {
   }, [playbackSessionRef]);
 
   const refreshPlaybackTimeline = useCallback(async (timelineUrl: string, signal?: AbortSignal) => {
-    const response = await fetch(timelineUrl, { cache: 'no-store', signal });
-    if (!response.ok) {
-      throw new Error(`Failed to load TTS playback timeline: ${response.status}`);
-    }
-    const timeline = normalizePlaybackGrid(await response.json());
-    playbackTimelineRef.current = timeline;
-    return timeline;
+    return timelineLoaderRef.current!.refresh(timelineUrl, signal);
   }, []);
 
   const projectPlaybackTime = useCallback((currentTimeSec: number) => {
@@ -216,6 +224,7 @@ export function usePlaybackProjection(input: UsePlaybackProjectionInput) {
 
   const resetPlaybackProjection = useCallback(() => {
     stopPlaybackProjectionLoop();
+    timelineLoaderRef.current?.reset();
     playbackTimelineRef.current = null;
     playbackStreamBaseSecRef.current = 0;
     lastProjectionRef.current = null;

--- a/src/hooks/audio/usePlaybackProjection.ts
+++ b/src/hooks/audio/usePlaybackProjection.ts
@@ -16,6 +16,7 @@ import { createPlaybackTimelineLoader } from '@/lib/client/tts/playback-refresh'
 
 export type PlaybackSessionState = {
   sessionId: string;
+  sessionInstanceId?: string;
   audioUrl: string;
   timelineUrl: string;
   seekLayoutUrl?: string;

--- a/src/hooks/audio/usePlaybackProjection.ts
+++ b/src/hooks/audio/usePlaybackProjection.ts
@@ -16,7 +16,7 @@ import { createPlaybackTimelineLoader } from '@/lib/client/tts/playback-refresh'
 
 export type PlaybackSessionState = {
   sessionId: string;
-  sessionInstanceId?: string;
+  sessionInstanceId: string;
   audioUrl: string;
   timelineUrl: string;
   seekLayoutUrl?: string;

--- a/src/hooks/audio/useTtsPlayback.ts
+++ b/src/hooks/audio/useTtsPlayback.ts
@@ -106,7 +106,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   const playbackRequestAbortRef = useRef<AbortController | null>(null);
   const playbackRecoveryRef = useRef<ReturnType<typeof createPlaybackRecovery> | null>(null);
   const latestSeekLayoutRef = useRef(playbackSeekLayout);
-  latestSeekLayoutRef.current = playbackSeekLayout;
+  useEffect(() => { latestSeekLayoutRef.current = playbackSeekLayout; }, [playbackSeekLayout]);
   const checkRecovery = useCallback(() => { playbackRecoveryRef.current?.check(); }, []);
   const playbackPhaseRef = useRef<TtsPlaybackPhase>('idle');
   const [playbackPhase, setPlaybackPhaseState] = useState<TtsPlaybackPhase>('idle');
@@ -466,6 +466,14 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
 
   const playWorkerPlaybackStream = useCallback(async () => {
     const runId = playbackRunIdRef.current;
+    // React may flush the effect that requested this start immediately after
+    // the user canceled it. The intent ref changes synchronously, so check it
+    // before stale work can put the controls back into a processing state.
+    if (!isPlayingRef.current) {
+      playbackInFlightRef.current = false;
+      setIsProcessing(false);
+      return;
+    }
     const request = controller.buildPlaybackPlanRequest();
     if (!request) {
       playbackInFlightRef.current = false;

--- a/src/hooks/audio/useTtsPlayback.ts
+++ b/src/hooks/audio/useTtsPlayback.ts
@@ -20,9 +20,12 @@ import type { TtsPlaybackPlan } from '@/lib/shared/playback-plan';
 import {
   isPlaybackAbortError,
   isPlaybackStartBufferReady,
+  resumePlaybackMedia,
   waitForPlaybackStartBuffer,
 } from '@/lib/client/tts/playback-control';
 import { usePlaybackMediaResume } from '@/hooks/audio/usePlaybackMediaResume';
+import { createPlaybackRecovery, createTtsMediaRecovery } from '@/lib/client/tts/playback-recovery';
+import { installPlaybackMediaEvents } from '@/lib/client/tts/playback-media-events';
 import { usePlaybackForegroundSync } from '@/hooks/audio/usePlaybackForegroundSync';
 import {
   usePlaybackProjection,
@@ -101,7 +104,10 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   const resyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const playbackRequestHeadersRef = useRef<TTSRequestHeaders | null>(null);
   const playbackRequestAbortRef = useRef<AbortController | null>(null);
-  const playbackResumeRunIdRef = useRef<number | null>(null);
+  const playbackRecoveryRef = useRef<ReturnType<typeof createPlaybackRecovery> | null>(null);
+  const latestSeekLayoutRef = useRef(playbackSeekLayout);
+  latestSeekLayoutRef.current = playbackSeekLayout;
+  const checkRecovery = useCallback(() => { playbackRecoveryRef.current?.check(); }, []);
   const playbackPhaseRef = useRef<TtsPlaybackPhase>('idle');
   const [playbackPhase, setPlaybackPhaseState] = useState<TtsPlaybackPhase>('idle');
 
@@ -159,7 +165,8 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
 
   const invalidatePlaybackRun = useCallback(() => {
     playbackRunIdRef.current += 1;
-    playbackResumeRunIdRef.current = null;
+    playbackRecoveryRef.current?.stop();
+    playbackRecoveryRef.current = null;
     playbackInFlightRef.current = false;
     playbackRequestAbortRef.current?.abort();
     playbackRequestAbortRef.current = null;
@@ -213,12 +220,14 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     }
   }, [audioContext]);
 
-  const resetPlaybackRefs = useCallback((options?: { preserveProjection?: boolean }) => {
+  const resetPlaybackRefs = useCallback(() => {
+    playbackRecoveryRef.current?.stop();
+    playbackRecoveryRef.current = null;
     stopPlaybackForegroundSync();
     playbackActiveRef.current = false;
     playbackSessionRef.current = null;
     playbackRequestHeadersRef.current = null;
-    if (!options?.preserveProjection) resetPlaybackProjection();
+    resetPlaybackProjection();
     setPlaybackPhase('idle');
   }, [resetPlaybackProjection, setPlaybackPhase, stopPlaybackForegroundSync]);
 
@@ -297,7 +306,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
         return;
       }
       const headers = playbackRequestHeadersRef.current;
-      if (headers) void postTtsPlaybackCursor(session.sessionId, ordinal, headers);
+      if (headers) void postTtsPlaybackCursor(session.sessionId, ordinal, headers, { sessionInstanceId: session.sessionInstanceId });
 
       const layout = await getTtsPlaybackSeekLayout(session.seekLayoutUrl).catch(() => null);
       if (runId !== playbackRunIdRef.current || pendingResyncRef.current?.ordinal !== ordinal) return;
@@ -375,7 +384,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     const session = playbackSessionRef.current;
     const headers = playbackRequestHeadersRef.current;
     if (session && headers) {
-      void postTtsPlaybackCursor(session.sessionId, target.ordinal, headers);
+      void postTtsPlaybackCursor(session.sessionId, target.ordinal, headers, { sessionInstanceId: session.sessionInstanceId });
     }
 
     const audio = unlockedAudioRef.current;
@@ -455,7 +464,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     return seekPlaybackToOrdinal(ordinal);
   }, [seekPlaybackToOrdinal]);
 
-  const playWorkerPlaybackStream = useCallback(async (options?: { preserveProjection?: boolean }) => {
+  const playWorkerPlaybackStream = useCallback(async () => {
     const runId = playbackRunIdRef.current;
     const request = controller.buildPlaybackPlanRequest();
     if (!request) {
@@ -464,7 +473,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       return;
     }
 
-    resetPlaybackRefs(options);
+    resetPlaybackRefs();
     setIsProcessing(true);
     setPlaybackPhase('planning');
     if (unlockedAudioRef.current) {
@@ -514,6 +523,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
 
       playbackSessionRef.current = {
         sessionId: session.sessionId,
+        sessionInstanceId: session.sessionInstanceId,
         audioUrl: session.audioUrl,
         timelineUrl: session.timelineUrl,
         seekLayoutUrl: session.seekLayoutUrl,
@@ -525,6 +535,8 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
 
       const requestedStartOrdinal = Math.max(0, Math.floor(Number(selectedOrdinal)));
       playbackCursorOrdinalRef.current = requestedStartOrdinal;
+      await setWorkerPlaybackActive(true, true);
+      if (runId !== playbackRunIdRef.current || !isPlayingRef.current) return;
       startPlaybackForegroundSync(runId, headers);
 
       const initialSeekLayout = await waitForPlaybackStartBuffer({
@@ -562,91 +574,75 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       audio.defaultPlaybackRate = audioSpeed;
       audio.playbackRate = audioSpeed;
       audio.volume = 1;
-      audio.onplay = () => {
-        if (runId !== playbackRunIdRef.current || !isPlayingRef.current || audio.paused) return;
-        // `play` only means the element accepted the request and is no longer
-        // paused. It can still spend many seconds waiting for generated bytes.
-        // `playing` below is the event that establishes audible playback.
-        setPlaybackPhase('buffering');
-        audio.playbackRate = audioSpeed;
-        setIsProcessing(true);
-      };
-      audio.onpause = () => {
-        if (runId !== playbackRunIdRef.current) return;
-        stopPlaybackProjectionLoop();
-        playbackInFlightRef.current = false;
-        setPlaybackPhase('ready');
-        if ('mediaSession' in navigator) {
-          navigator.mediaSession.playbackState = 'paused';
-        }
-      };
-      audio.onended = () => {
-        if (runId !== playbackRunIdRef.current) return;
-        setWorkerPlaybackActive(false);
-        stopPlaybackProjectionLoop();
-        playbackInFlightRef.current = false;
-        setIsProcessing(false);
-        resetPlaybackRefs();
-        setPlaybackPhase('ended');
-        playbackRequestHeadersRef.current = null;
-        if (isPlayingRef.current) {
-          void onAdvance();
-        }
-      };
-      audio.onerror = () => {
-        if (runId !== playbackRunIdRef.current) return;
-        if (playbackResumeRunIdRef.current === runId) return;
-        setWorkerPlaybackActive(false);
-        stopPlaybackProjectionLoop();
-        playbackInFlightRef.current = false;
-        setIsProcessing(false);
-        resetPlaybackRefs();
-        setPlaybackPhase('failed');
-        playbackRequestHeadersRef.current = null;
-        setIsPlaying(false);
-        toast.error('TTS playback failed. Paused playback.', {
-          id: 'tts-playback-error',
-          duration: 7000,
-        });
-      };
-      audio.ontimeupdate = () => {
-        if (runId !== playbackRunIdRef.current) return;
-        const documentTimeSec = documentTimeForAudio(audio);
-        publishPlaybackTimeSec(documentTimeSec, { force: true });
-        projectPlaybackTime(documentTimeSec);
-      };
-      audio.onwaiting = () => {
-        // Chromium can deliver a queued `waiting` event after the user has
-        // already paused. Never let that stale event put a paused control back
-        // into an indefinitely disabled processing state.
-        if (runId !== playbackRunIdRef.current || !isPlayingRef.current || audio.paused) return;
-        setPlaybackPhase('buffering');
-        setIsProcessing(true);
-      };
-      audio.onstalled = null;
-      audio.onplaying = () => {
-        if (runId !== playbackRunIdRef.current || !isPlayingRef.current || audio.paused) return;
-        setPlaybackPhase('playing');
-        startPlaybackProjectionLoop(audio, runId);
-        setIsProcessing(false);
-        if ('mediaSession' in navigator) {
-          navigator.mediaSession.playbackState = 'playing';
-        }
-      };
+      const recover = () => { setPlaybackPhase('buffering'); setIsProcessing(true); checkRecovery(); };
+      installPlaybackMediaEvents({ audio, audioSpeed,
+        isCurrent: () => runId === playbackRunIdRef.current,
+        isPlaying: () => isPlayingRef.current,
+        shouldRecoverEnd: () => {
+          const last = latestSeekLayoutRef.current?.segments.at(-1)?.ordinal;
+          return last !== undefined && (playbackCursorOrdinalRef.current ?? 0) < last;
+        },
+        onPause: () => {
+          stopPlaybackProjectionLoop();
+          playbackInFlightRef.current = isPlayingRef.current;
+          setPlaybackPhase(isPlayingRef.current ? 'buffering' : 'ready');
+        },
+        onBuffering: recover, onRecover: recover,
+        onEnded: () => {
+          setWorkerPlaybackActive(false); stopPlaybackProjectionLoop();
+          playbackInFlightRef.current = false; setIsProcessing(false); resetPlaybackRefs();
+          setPlaybackPhase('ended'); playbackRequestHeadersRef.current = null;
+          if (isPlayingRef.current) void onAdvance();
+        },
+        onTime: () => {
+          const documentTimeSec = documentTimeForAudio(audio);
+          publishPlaybackTimeSec(documentTimeSec, { force: true });
+          projectPlaybackTime(documentTimeSec);
+        },
+        onPlaying: () => {
+          setPlaybackPhase('playing'); startPlaybackProjectionLoop(audio, runId); setIsProcessing(false);
+        },
+      });
 
       playbackActiveRef.current = true;
       playbackStreamBaseSecRef.current = initialStartSec;
       audio.src = session.audioUrl;
       audio.load();
+      const activeSession = playbackSessionRef.current;
+      playbackRecoveryRef.current = createTtsMediaRecovery({
+        audio,
+        sessionUrl: session.audioUrl,
+        isCurrent: () => runId === playbackRunIdRef.current && isPlayingRef.current
+          && playbackActiveRef.current && playbackSessionRef.current === activeSession
+          && !pendingResyncRef.current,
+        getDocumentTime: () => documentTimeForAudio(audio),
+        getOrdinal: () => playbackCursorOrdinalRef.current,
+        getLayout: () => latestSeekLayoutRef.current,
+        setStreamBase: (seconds) => { playbackStreamBaseSecRef.current = seconds; },
+        onBuffering: () => {
+          setPlaybackPhase('buffering');
+          setIsProcessing(true);
+        },
+        onExhausted: () => {
+          pauseActivePlayback();
+          setIsPlaying(false);
+          setPlaybackPhase('failed');
+          toast.error('Audio is ready, but playback could not reconnect. Try Play again.', { id: 'tts-playback-error' });
+        },
+      });
       publishPlaybackTimeSec(initialStartSec, { force: true });
       projectPlaybackTime(initialStartSec);
-      await audio.play();
+      const started = await resumePlaybackMedia(() => audio.play(), () => (
+        runId === playbackRunIdRef.current && isPlayingRef.current
+      ));
+      if (started.status === 'stale') checkRecovery();
       if (runId === playbackRunIdRef.current && !audio.paused && !audio.ended) {
         startPlaybackProjectionLoop(audio, runId);
       }
     } catch (error) {
       if (runId !== playbackRunIdRef.current || isPlaybackAbortError(error)) return;
       console.error('Error playing TTS playback:', error);
+      setWorkerPlaybackActive(false);
       stopPlaybackProjectionLoop();
       playbackInFlightRef.current = false;
       setIsProcessing(false);
@@ -661,9 +657,11 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   }, [
     audioSpeed,
     controller,
+    checkRecovery,
     documentTimeForAudio,
     isPlayingRef,
     onAdvance,
+    pauseActivePlayback,
     playbackCursorOrdinalRef,
     playbackRunIdRef,
     playbackSegmentsRef,
@@ -683,28 +681,18 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     stopPlaybackProjectionLoop,
   ]);
 
-  const reconnectPlaybackStream = useCallback(() => {
-    void playWorkerPlaybackStream({ preserveProjection: true });
-  }, [playWorkerPlaybackStream]);
   const resumeActivePlayback = usePlaybackMediaResume({
     audioSpeed,
     isPlayingRef,
-    playbackActiveRef,
     playbackInFlightRef,
     playbackRequestHeadersRef,
-    playbackResumeRunIdRef,
     playbackRunIdRef,
-    playbackSessionRef,
-    cancelSeekResync,
-    invalidatePlaybackRun,
-    reconnectPlaybackStream,
+    checkRecovery,
     setIsPlaying,
     setIsProcessing,
     setPlaybackPhase,
     setWorkerPlaybackActive,
     startPlaybackForegroundSync,
-    stopPlaybackForegroundSync,
-    stopPlaybackProjectionLoop,
   });
 
   const togglePlay = useCallback(() => {
@@ -757,10 +745,13 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       return;
     }
     if (!canStartPlayback) return;
+    if (playbackActiveRef.current) return;
     if (playbackInFlightRef.current) return;
     playbackInFlightRef.current = true;
     void playWorkerPlaybackStream();
   }, [canStartPlayback, isPlaying, playWorkerPlaybackStream]);
+
+  useEffect(() => () => { playbackRecoveryRef.current?.stop(); }, []);
 
   useEffect(() => {
     const onVisibilityChange = () => {

--- a/src/hooks/audio/useTtsPlayback.ts
+++ b/src/hooks/audio/useTtsPlayback.ts
@@ -528,6 +528,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
         }
       })();
       if (runId !== playbackRunIdRef.current) return;
+      if (!session.sessionInstanceId) throw new Error('Prepared TTS playback session was missing its instance identity');
 
       playbackSessionRef.current = {
         sessionId: session.sessionId,

--- a/src/lib/client/api/tts.ts
+++ b/src/lib/client/api/tts.ts
@@ -25,6 +25,7 @@ export const createTtsPlaybackSession = async (
   signal?: AbortSignal,
 ): Promise<{
   sessionId: string;
+  sessionInstanceId?: string;
   operation: unknown;
   audioUrl: string;
   timelineUrl: string;
@@ -277,8 +278,10 @@ export const subscribeTtsPlaybackEvents = (
     onSnapshot: (snapshot: TtsPlaybackEventSnapshot) => void;
     onError?: (error: Event) => void;
   },
+  operationId?: string,
 ): (() => void) => {
-  const source = new EventSource(`/api/tts/stream/${encodeURIComponent(sessionId)}/events`);
+  const suffix = operationId ? `?operationId=${encodeURIComponent(operationId)}` : '';
+  const source = new EventSource(`/api/tts/stream/${encodeURIComponent(sessionId)}/events${suffix}`);
   source.addEventListener('snapshot', (event) => {
     if (!(event instanceof MessageEvent)) return;
     try {
@@ -455,18 +458,24 @@ export const postTtsPlaybackCursor = async (
   sessionId: string,
   ordinal: number,
   headers: TTSRequestHeaders,
-  options?: { keepalive?: boolean; signal?: AbortSignal; playbackActive?: boolean },
-): Promise<void> => {
-  await fetch(`/api/tts/stream/${encodeURIComponent(sessionId)}/cursor`, {
+  options?: { keepalive?: boolean; signal?: AbortSignal; playbackActive?: boolean; sessionInstanceId?: string; requireAcknowledgement?: boolean },
+): Promise<{ workerOpId: string | null } | null> => {
+  const response = await fetch(`/api/tts/stream/${encodeURIComponent(sessionId)}/cursor`, {
     method: 'POST',
     headers: headers as HeadersInit,
     body: JSON.stringify({
       ordinal,
+      ...(options?.sessionInstanceId === undefined ? {} : { sessionInstanceId: options.sessionInstanceId }),
       ...(options?.playbackActive === undefined
         ? {}
         : { playbackActive: options.playbackActive }),
     }),
     keepalive: options?.keepalive ?? false,
-    signal: options?.signal,
-  }).catch(() => undefined);
+    signal: AbortSignal.any([AbortSignal.timeout(10_000), ...(options?.signal ? [options.signal] : [])]),
+  }).catch(() => null);
+  if (!response?.ok) {
+    if (options?.requireAcknowledgement) throw new Error('Playback activation could not be confirmed');
+    return null;
+  }
+  return response.json().catch(() => null);
 };

--- a/src/lib/client/api/tts.ts
+++ b/src/lib/client/api/tts.ts
@@ -458,23 +458,23 @@ export const postTtsPlaybackCursor = async (
   sessionId: string,
   ordinal: number,
   headers: TTSRequestHeaders,
-  options?: { keepalive?: boolean; signal?: AbortSignal; playbackActive?: boolean; sessionInstanceId?: string; requireAcknowledgement?: boolean },
+  options: { keepalive?: boolean; signal?: AbortSignal; playbackActive?: boolean; sessionInstanceId: string; requireAcknowledgement?: boolean },
 ): Promise<{ workerOpId: string | null } | null> => {
   const response = await fetch(`/api/tts/stream/${encodeURIComponent(sessionId)}/cursor`, {
     method: 'POST',
     headers: headers as HeadersInit,
     body: JSON.stringify({
       ordinal,
-      ...(options?.sessionInstanceId === undefined ? {} : { sessionInstanceId: options.sessionInstanceId }),
-      ...(options?.playbackActive === undefined
+      sessionInstanceId: options.sessionInstanceId,
+      ...(options.playbackActive === undefined
         ? {}
         : { playbackActive: options.playbackActive }),
     }),
-    keepalive: options?.keepalive ?? false,
-    signal: AbortSignal.any([AbortSignal.timeout(10_000), ...(options?.signal ? [options.signal] : [])]),
+    keepalive: options.keepalive ?? false,
+    signal: AbortSignal.any([AbortSignal.timeout(10_000), ...(options.signal ? [options.signal] : [])]),
   }).catch(() => null);
   if (!response?.ok) {
-    if (options?.requireAcknowledgement) throw new Error('Playback activation could not be confirmed');
+    if (options.requireAcknowledgement) throw new Error('Playback activation could not be confirmed');
     return null;
   }
   return response.json().catch(() => null);

--- a/src/lib/client/tts/playback-media-events.ts
+++ b/src/lib/client/tts/playback-media-events.ts
@@ -16,7 +16,7 @@ export function installPlaybackMediaEvents(input: {
     if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'paused';
   };
   audio.onended = () => {
-    if (!input.isCurrent() || !input.isPlaying()) return;
+    if (!input.isCurrent()) return;
     if (input.shouldRecoverEnd()) input.onRecover(); else input.onEnded();
   };
   audio.onerror = () => { if (input.isCurrent() && input.isPlaying()) input.onRecover(); };

--- a/src/lib/client/tts/playback-media-events.ts
+++ b/src/lib/client/tts/playback-media-events.ts
@@ -1,0 +1,33 @@
+/** Centralize media-element event policy so connection churn cannot change intent. */
+export function installPlaybackMediaEvents(input: {
+  audio: HTMLAudioElement; audioSpeed: number;
+  isCurrent: () => boolean; isPlaying: () => boolean; shouldRecoverEnd: () => boolean;
+  onPause: () => void; onBuffering: () => void; onRecover: () => void;
+  onEnded: () => void; onTime: () => void; onPlaying: () => void;
+}) {
+  const { audio } = input;
+  audio.onplay = () => {
+    if (!input.isCurrent() || !input.isPlaying() || audio.paused) return;
+    audio.playbackRate = input.audioSpeed; input.onBuffering();
+  };
+  audio.onpause = () => {
+    if (!input.isCurrent()) return;
+    input.onPause();
+    if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'paused';
+  };
+  audio.onended = () => {
+    if (!input.isCurrent() || !input.isPlaying()) return;
+    if (input.shouldRecoverEnd()) input.onRecover(); else input.onEnded();
+  };
+  audio.onerror = () => { if (input.isCurrent() && input.isPlaying()) input.onRecover(); };
+  audio.ontimeupdate = () => { if (input.isCurrent()) input.onTime(); };
+  audio.onwaiting = () => {
+    if (input.isCurrent() && input.isPlaying() && !audio.paused) input.onBuffering();
+  };
+  audio.onstalled = null;
+  audio.onplaying = () => {
+    if (!input.isCurrent() || !input.isPlaying() || audio.paused) return;
+    input.onPlaying();
+    if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'playing';
+  };
+}

--- a/src/lib/client/tts/playback-recovery.ts
+++ b/src/lib/client/tts/playback-recovery.ts
@@ -1,0 +1,82 @@
+import type { TtsPlaybackSeekLayout } from '@/lib/client/api/tts';
+import { isPlaybackStartBufferReady } from '@/lib/client/tts/playback-control';
+
+/** Watch the local media clock; readiness comes from the existing SSE read model. */
+export function createPlaybackRecovery<T>(input: {
+  isCurrent: () => boolean;
+  currentTime: () => number;
+  readyTarget: () => T | null;
+  reconnect: (target: T) => void;
+  onExhausted: () => void;
+  now?: () => number;
+}) {
+  const now = input.now ?? Date.now;
+  let lastTime = input.currentTime();
+  let lastAdvance = now();
+  let attempts = 0;
+  let stopped = false;
+  const check = () => {
+    if (stopped) return;
+    const time = input.currentTime();
+    if (!input.isCurrent() || Math.abs(time - lastTime) > 0.05) {
+      lastTime = time;
+      lastAdvance = now();
+      attempts = 0;
+      return;
+    }
+    if (now() - lastAdvance < 5_000) return;
+    const target = input.readyTarget();
+    if (target === null) return; // Still generating: reloading cannot help.
+    lastAdvance = now();
+    if (attempts >= 2) {
+      attempts = 0;
+      input.onExhausted();
+      return;
+    }
+    attempts++;
+    input.reconnect(target);
+    lastTime = input.currentTime(); // A media reload is not audible progress.
+  };
+  const timer = setInterval(check, 1_000);
+  return { check, stop: () => { stopped = true; clearInterval(timer); } };
+}
+
+/** Reopen a dead media connection without replacing its canonical session. */
+export function createTtsMediaRecovery(input: {
+  audio: HTMLAudioElement;
+  sessionUrl: string;
+  isCurrent: () => boolean;
+  getDocumentTime: () => number;
+  getOrdinal: () => number | null;
+  getLayout: () => TtsPlaybackSeekLayout | null;
+  setStreamBase: (seconds: number) => void;
+  onBuffering: () => void;
+  onExhausted: () => void;
+}) {
+  return createPlaybackRecovery({
+    isCurrent: input.isCurrent,
+    currentTime: input.getDocumentTime,
+    readyTarget: () => {
+      const layout = input.getLayout();
+      const ordinal = input.getOrdinal();
+      const slot = layout?.segments.find((segment) => segment.ordinal === ordinal);
+      if (!layout || !slot?.generated) return null;
+      const documentTime = input.getDocumentTime();
+      return isPlaybackStartBufferReady({
+        segments: layout.segments, startOrdinal: slot.ordinal, playbackRate: input.audio.playbackRate,
+        offsetWithinStartSegmentMs: Math.max(0, documentTime * 1000 - slot.startMs),
+      }) ? { slot, documentTime } : null;
+    },
+    reconnect: ({ slot, documentTime }) => {
+      const url = new URL(input.sessionUrl, window.location.href);
+      url.searchParams.set('fromOrdinal', String(slot.ordinal));
+      input.setStreamBase(slot.startMs / 1000);
+      input.audio.src = url.toString();
+      input.audio.load();
+      input.audio.currentTime = Math.max(0, documentTime - slot.startMs / 1000);
+      input.onBuffering();
+      void input.audio.play().catch(() => undefined);
+    },
+    onExhausted: input.onExhausted,
+  });
+}

--- a/src/lib/client/tts/playback-refresh.ts
+++ b/src/lib/client/tts/playback-refresh.ts
@@ -1,0 +1,71 @@
+/** Coalesce an event burst into one active read and one trailing read, never a queue per event. */
+export function createCoalescedPlaybackRefresh(refresh: (signal: AbortSignal) => Promise<unknown>) {
+  const controller = new AbortController();
+  let running = false;
+  let pending = false;
+  const request = () => {
+    if (controller.signal.aborted) return;
+    pending = true;
+    if (running) return;
+    running = true;
+    void (async () => {
+      try {
+        while (pending && !controller.signal.aborted) {
+          pending = false;
+          await refresh(controller.signal).catch(() => undefined);
+        }
+      } finally {
+        running = false;
+      }
+    })();
+  };
+  return { request, stop: () => { pending = false; controller.abort(); } };
+}
+
+/** Share in-flight timeline reads and prevent a late response from reviving an old playback run. */
+export function createPlaybackTimelineLoader<T>(input: {
+  load: (url: string, signal: AbortSignal) => Promise<T>;
+  getRunId: () => number;
+  getSession: () => { timelineUrl: string } | null;
+  apply: (timeline: T) => void;
+}) {
+  type Read = {
+    url: string;
+    runId: number;
+    session: ReturnType<typeof input.getSession>;
+    controller: AbortController;
+    signal: AbortSignal;
+    promise?: Promise<T>;
+  };
+  let active: Read | null = null;
+  const reset = () => {
+    active?.controller.abort();
+    active = null;
+  };
+  const refresh = (url: string, signal?: AbortSignal): Promise<T> => {
+    const runId = input.getRunId();
+    const session = input.getSession();
+    if (active?.url === url && active.runId === runId && active.session === session
+      && !active.signal.aborted && active.promise) return active.promise;
+    reset();
+    const controller = new AbortController();
+    const combinedSignal = AbortSignal.any([
+      controller.signal, AbortSignal.timeout(30_000), ...(signal ? [signal] : []),
+    ]);
+    const read: Read = { url, runId, session, controller, signal: combinedSignal };
+    active = read;
+    read.promise = (async () => {
+      try {
+        const timeline = await input.load(url, combinedSignal);
+        if (active === read && !combinedSignal.aborted
+          && input.getRunId() === runId && input.getSession() === session
+          && session?.timelineUrl === url) input.apply(timeline);
+        return timeline;
+      } finally {
+        if (active === read) active = null;
+      }
+    })();
+    return read.promise;
+  };
+  return { refresh, reset };
+}

--- a/src/lib/client/tts/playback-refresh.ts
+++ b/src/lib/client/tts/playback-refresh.ts
@@ -69,3 +69,26 @@ export function createPlaybackTimelineLoader<T>(input: {
   };
   return { refresh, reset };
 }
+/** Retarget operation-scoped SSE on the existing cursor heartbeat, without polling. */
+export function createPlaybackOperationSubscription<T>(input: {
+  subscribe: (operationId: string, onSnapshot: (snapshot: T) => void) => () => void;
+  onSnapshot: (snapshot: T) => void;
+}) {
+  let current: string | null = null;
+  let unsubscribe: (() => void) | null = null;
+  let stopped = false;
+  return {
+    update(operationId: string | null) {
+      if (stopped || current === operationId) return;
+      unsubscribe?.();
+      unsubscribe = null;
+      current = operationId;
+      if (operationId) {
+        unsubscribe = input.subscribe(operationId, (snapshot) => {
+          if (!stopped && current === operationId) input.onSnapshot(snapshot);
+        });
+      }
+    },
+    stop() { stopped = true; unsubscribe?.(); unsubscribe = null; },
+  };
+}

--- a/src/lib/client/tts/playback-refresh.ts
+++ b/src/lib/client/tts/playback-refresh.ts
@@ -35,9 +35,20 @@ export function createPlaybackTimelineLoader<T>(input: {
     session: ReturnType<typeof input.getSession>;
     controller: AbortController;
     signal: AbortSignal;
+    scopeSignal?: AbortSignal;
     promise?: Promise<T>;
   };
   let active: Read | null = null;
+  const waitForRead = (promise: Promise<T>, signal: AbortSignal): Promise<void> => {
+    if (signal.aborted) return Promise.reject(signal.reason);
+    return new Promise<void>((resolve, reject) => {
+      const onAbort = () => reject(signal.reason);
+      signal.addEventListener('abort', onAbort, { once: true });
+      void promise.then(() => resolve(), () => resolve()).finally(() => {
+        signal.removeEventListener('abort', onAbort);
+      });
+    });
+  };
   const reset = () => {
     active?.controller.abort();
     active = null;
@@ -46,13 +57,23 @@ export function createPlaybackTimelineLoader<T>(input: {
     const runId = input.getRunId();
     const session = input.getSession();
     if (active?.url === url && active.runId === runId && active.session === session
-      && !active.signal.aborted && active.promise) return active.promise;
+      && !active.signal.aborted && active.promise) {
+      if (active.scopeSignal === signal || (active.scopeSignal !== undefined && signal === undefined)) {
+        return active.promise;
+      }
+      if (active.scopeSignal === undefined && signal !== undefined) {
+        // Do not abort a startup/timing-heal read that another caller awaits.
+        // The foreground subscriber still gets one exact trailing read, and
+        // its own stop signal can cancel the wait before that read starts.
+        return waitForRead(active.promise, signal).then(() => refresh(url, signal));
+      }
+    }
     reset();
     const controller = new AbortController();
     const combinedSignal = AbortSignal.any([
       controller.signal, AbortSignal.timeout(30_000), ...(signal ? [signal] : []),
     ]);
-    const read: Read = { url, runId, session, controller, signal: combinedSignal };
+    const read: Read = { url, runId, session, controller, signal: combinedSignal, scopeSignal: signal };
     active = read;
     read.promise = (async () => {
       try {

--- a/src/lib/server/compute-worker/client.ts
+++ b/src/lib/server/compute-worker/client.ts
@@ -10,6 +10,9 @@ import type {
   AccountExportResolveRequest,
   AccountExportResolution,
   TtsPlaybackRequest,
+  TtsPlaybackSessionPrepareRequest,
+  TtsPlaybackSessionPrepareResponse,
+  TtsPlaybackCursorResponse,
   TtsPlaybackExportArtifactRequest,
   TtsPlaybackExportArtifactResolution,
   TtsPlaybackPlanRequest,
@@ -135,9 +138,10 @@ export class ComputeWorkerClient {
     return this.requestJson('POST', '/v1/tts-playback/plans/jobs', input);
   }
 
-  prepareTtsPlaybackSession(input: TtsPlaybackRequest, init?: { signal?: AbortSignal }): Promise<{
-    sessionId: string; sessionInstanceId: string;
-  }> {
+  prepareTtsPlaybackSession(
+    input: TtsPlaybackSessionPrepareRequest,
+    init?: { signal?: AbortSignal },
+  ): Promise<TtsPlaybackSessionPrepareResponse> {
     return this.requestJson('POST', '/v1/tts-playback/sessions/prepare', input, init);
   }
 
@@ -205,7 +209,7 @@ export class ComputeWorkerClient {
     ordinal: number;
     playbackActive?: boolean;
     expiresAt?: number;
-  }): Promise<{ sessionId: string; cursorOrdinal: number; playbackActive: boolean; expiresAt: number; workerOpId: string | null }> {
+  }): Promise<TtsPlaybackCursorResponse> {
     return this.requestJson('PUT', `/v1/tts-playback/sessions/${encodeURIComponent(input.sessionId)}/cursor`, {
       ...(input.sessionInstanceId === undefined ? {} : { sessionInstanceId: input.sessionInstanceId }),
       ordinal: input.ordinal,

--- a/src/lib/server/compute-worker/client.ts
+++ b/src/lib/server/compute-worker/client.ts
@@ -135,6 +135,12 @@ export class ComputeWorkerClient {
     return this.requestJson('POST', '/v1/tts-playback/plans/jobs', input);
   }
 
+  prepareTtsPlaybackSession(input: TtsPlaybackRequest, init?: { signal?: AbortSignal }): Promise<{
+    sessionId: string; sessionInstanceId: string;
+  }> {
+    return this.requestJson('POST', '/v1/tts-playback/sessions/prepare', input, init);
+  }
+
   createTtsPlaybackExportArtifactOperation(input: TtsPlaybackExportArtifactRequest): Promise<ComputeOperation> {
     return this.requestJson('POST', '/v1/tts-playback/exports/jobs', input);
   }
@@ -195,11 +201,13 @@ export class ComputeWorkerClient {
 
   updateTtsPlaybackCursor(input: {
     sessionId: string;
+    sessionInstanceId?: string;
     ordinal: number;
     playbackActive?: boolean;
     expiresAt?: number;
-  }): Promise<{ sessionId: string; cursorOrdinal: number; playbackActive: boolean; expiresAt: number }> {
+  }): Promise<{ sessionId: string; cursorOrdinal: number; playbackActive: boolean; expiresAt: number; workerOpId: string | null }> {
     return this.requestJson('PUT', `/v1/tts-playback/sessions/${encodeURIComponent(input.sessionId)}/cursor`, {
+      ...(input.sessionInstanceId === undefined ? {} : { sessionInstanceId: input.sessionInstanceId }),
       ordinal: input.ordinal,
       ...(input.playbackActive === undefined ? {} : { playbackActive: input.playbackActive }),
       ...(input.expiresAt === undefined ? {} : { expiresAt: input.expiresAt }),

--- a/src/lib/server/compute-worker/client.ts
+++ b/src/lib/server/compute-worker/client.ts
@@ -212,7 +212,7 @@ export class ComputeWorkerClient {
     documentVersion?: number;
     readerType?: 'pdf' | 'epub' | 'html';
     namespace: string | null;
-  }): Promise<{
+  }, init?: { signal?: AbortSignal }): Promise<{
     deletedAudioObjects: number;
     deletedSidecarObjects: number;
     deletedPlanObjects: number;
@@ -220,7 +220,7 @@ export class ComputeWorkerClient {
     invalidatedPlaybackSessions: number;
     invalidatedJobOperations: number;
   }> {
-    return this.requestJson('POST', '/v1/tts-playback/cache/clear', input);
+    return this.requestJson('POST', '/v1/tts-playback/cache/clear', input, init);
   }
 
   cleanupUserStorage(input: {

--- a/src/lib/server/compute-worker/client.ts
+++ b/src/lib/server/compute-worker/client.ts
@@ -13,6 +13,7 @@ import type {
   TtsPlaybackSessionPrepareRequest,
   TtsPlaybackSessionPrepareResponse,
   TtsPlaybackCursorResponse,
+  TtsPlaybackCursorUpdateRequest,
   TtsPlaybackExportArtifactRequest,
   TtsPlaybackExportArtifactResolution,
   TtsPlaybackPlanRequest,
@@ -203,19 +204,15 @@ export class ComputeWorkerClient {
     return this.requestJson('GET', `/v1/tts-playback/sessions/${encodeURIComponent(input.sessionId)}/segments${suffix}`);
   }
 
-  updateTtsPlaybackCursor(input: {
-    sessionId: string;
-    sessionInstanceId?: string;
-    ordinal: number;
-    playbackActive?: boolean;
-    expiresAt?: number;
-  }): Promise<TtsPlaybackCursorResponse> {
-    return this.requestJson('PUT', `/v1/tts-playback/sessions/${encodeURIComponent(input.sessionId)}/cursor`, {
-      ...(input.sessionInstanceId === undefined ? {} : { sessionInstanceId: input.sessionInstanceId }),
-      ordinal: input.ordinal,
-      ...(input.playbackActive === undefined ? {} : { playbackActive: input.playbackActive }),
-      ...(input.expiresAt === undefined ? {} : { expiresAt: input.expiresAt }),
-    });
+  updateTtsPlaybackCursor(
+    input: TtsPlaybackCursorUpdateRequest & { sessionId: string },
+  ): Promise<TtsPlaybackCursorResponse> {
+    const { sessionId, ...body } = input;
+    return this.requestJson(
+      'PUT',
+      `/v1/tts-playback/sessions/${encodeURIComponent(sessionId)}/cursor`,
+      body,
+    );
   }
 
   clearTtsPlaybackScope(input: {

--- a/src/lib/server/compute-worker/generated.ts
+++ b/src/lib/server/compute-worker/generated.ts
@@ -211,7 +211,7 @@ export interface paths {
                         };
                         sessionId: string;
                         planObjectKey: string;
-                        generationRunId?: string;
+                        generationRunId: string;
                         expiresAt?: number;
                         aheadWindow?: number;
                         /** @enum {string} */
@@ -597,6 +597,21 @@ export interface paths {
                 };
             };
             responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            sessionId: string;
+                            workerOpId: string | null;
+                            cursorOrdinal: number;
+                            playbackActive: boolean;
+                            expiresAt: number;
+                        };
+                    };
+                };
                 /** @description Default Response */
                 400: {
                     headers: {

--- a/src/lib/server/compute-worker/generated.ts
+++ b/src/lib/server/compute-worker/generated.ts
@@ -169,6 +169,118 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/tts-playback/sessions/prepare": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: string;
+                        storageUserId: string;
+                        documentId: string;
+                        documentVersion: number;
+                        /** @enum {string} */
+                        readerType: "pdf" | "epub" | "html";
+                        settingsHash: string;
+                        settingsJson: unknown;
+                        planning: {
+                            selectedOrdinal?: number;
+                            maxBlockLength?: number;
+                            enforceSourceBoundaries?: boolean;
+                            language?: string;
+                            documentSource?: {
+                                namespace: string | null;
+                                skipBlockKinds?: string[];
+                                /** @enum {string} */
+                                extent: "section" | "document";
+                                isPlainText?: boolean;
+                            };
+                        };
+                        sessionId: string;
+                        planObjectKey: string;
+                        generationRunId?: string;
+                        expiresAt?: number;
+                        aheadWindow?: number;
+                        /** @enum {string} */
+                        backgroundExtent?: "section" | "document";
+                        /** @enum {string} */
+                        generationExtent?: "window" | "document";
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            sessionId: string;
+                            sessionInstanceId: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/tts-playback/sessions/resolve": {
         parameters: {
             query?: never;
@@ -477,6 +589,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
+                        sessionInstanceId?: string;
                         ordinal: number;
                         playbackActive?: boolean;
                         expiresAt?: number;
@@ -499,6 +612,19 @@ export interface paths {
                 };
                 /** @description Default Response */
                 404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
                     headers: {
                         [name: string]: unknown;
                     };

--- a/src/lib/server/compute-worker/generated.ts
+++ b/src/lib/server/compute-worker/generated.ts
@@ -589,7 +589,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        sessionInstanceId?: string;
+                        sessionInstanceId: string;
                         ordinal: number;
                         playbackActive?: boolean;
                         expiresAt?: number;

--- a/src/lib/server/compute-worker/protocol.ts
+++ b/src/lib/server/compute-worker/protocol.ts
@@ -26,6 +26,12 @@ export type PdfLayoutRequest =
 export type TtsPlaybackRequest =
   paths['/v1/tts-playback/sessions/jobs']['post']['requestBody']['content']['application/json']
   & { generationExtent?: 'window' | 'document' };
+export type TtsPlaybackSessionPrepareRequest =
+  paths['/v1/tts-playback/sessions/prepare']['post']['requestBody']['content']['application/json'];
+export type TtsPlaybackSessionPrepareResponse =
+  paths['/v1/tts-playback/sessions/prepare']['post']['responses'][200]['content']['application/json'];
+export type TtsPlaybackCursorResponse =
+  paths['/v1/tts-playback/sessions/{sessionId}/cursor']['put']['responses'][200]['content']['application/json'];
 export type TtsPlaybackPlanRequest =
   Omit<TtsPlaybackRequest, 'sessionId' | 'planObjectKey' | 'generationRunId' | 'expiresAt' | 'aheadWindow' | 'backgroundExtent' | 'generationExtent'>;
 export type TtsPlaybackSessionResolveRequest =

--- a/src/lib/server/compute-worker/protocol.ts
+++ b/src/lib/server/compute-worker/protocol.ts
@@ -32,6 +32,8 @@ export type TtsPlaybackSessionPrepareResponse =
   paths['/v1/tts-playback/sessions/prepare']['post']['responses'][200]['content']['application/json'];
 export type TtsPlaybackCursorResponse =
   paths['/v1/tts-playback/sessions/{sessionId}/cursor']['put']['responses'][200]['content']['application/json'];
+export type TtsPlaybackCursorUpdateRequest =
+  paths['/v1/tts-playback/sessions/{sessionId}/cursor']['put']['requestBody']['content']['application/json'];
 export type TtsPlaybackPlanRequest =
   Omit<TtsPlaybackRequest, 'sessionId' | 'planObjectKey' | 'generationRunId' | 'expiresAt' | 'aheadWindow' | 'backgroundExtent' | 'generationExtent'>;
 export type TtsPlaybackSessionResolveRequest =

--- a/src/lib/server/reader/bootstrap-events.ts
+++ b/src/lib/server/reader/bootstrap-events.ts
@@ -1,5 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { getComputeWorkerClient } from '@/lib/server/compute-worker/client';
+import type { ComputeOperation, PdfLayoutResult } from '@/lib/server/compute-worker/protocol';
+import { resolvePdfOperationReadiness } from './bootstrap-progress';
 import {
   resolveReaderBootstrapState,
   type ReaderBootstrapResolveOptions,
@@ -10,6 +12,19 @@ const encoder = new TextEncoder();
 
 function frame(result: ReaderBootstrapResolution['result']): Uint8Array {
   return encoder.encode(`event: snapshot\ndata: ${JSON.stringify(result)}\n\n`);
+}
+
+function readWorkerSnapshot(value: string): ComputeOperation<PdfLayoutResult> | null {
+  try {
+    const data = value.split('\n').filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trimStart()).join('\n');
+    const snapshot = JSON.parse(data)?.snapshot;
+    return snapshot && typeof snapshot.opId === 'string'
+      && ['queued', 'running', 'succeeded', 'failed'].includes(snapshot.status)
+      ? snapshot : null;
+  } catch {
+    return null;
+  }
 }
 
 export function createReaderBootstrapEventStream(
@@ -57,7 +72,36 @@ export function createReaderBootstrapEventStream(
             while (boundary >= 0) {
               const upstreamFrame = buffer.slice(0, boundary);
               buffer = buffer.slice(boundary + 2);
+              if (upstreamFrame.startsWith(':')) {
+                controller.enqueue(encoder.encode(`${upstreamFrame}\n\n`));
+              }
               if (/^event:\s*snapshot\s*$/m.test(upstreamFrame)) {
+                const snapshot = readWorkerSnapshot(upstreamFrame);
+                if (!snapshot || snapshot.opId !== operationId) {
+                  boundary = buffer.indexOf('\n\n');
+                  continue;
+                }
+                if (snapshot.status === 'queued' || snapshot.status === 'running') {
+                  // The stream was authorized at entry. Progress is already in
+                  // this snapshot: do not turn every download checkpoint into
+                  // another database + worker round trip.
+                  if (resolution.result.status === 'pending'
+                    && resolution.result.progress?.kind === 'pdf-parse') {
+                    const progress = resolvePdfOperationReadiness(snapshot);
+                    if (progress) {
+                      resolution = progress;
+                      const updateSignature = JSON.stringify(resolution.result);
+                      if (updateSignature !== signature) {
+                        controller.enqueue(frame(resolution.result));
+                        signature = updateSignature;
+                      }
+                    }
+                  }
+                  boundary = buffer.indexOf('\n\n');
+                  continue;
+                }
+                // Only an operation boundary needs full readiness/auth checks
+                // and possibly a switch from PDF preparation to plan creation.
                 const next = await resolveReaderBootstrapState(
                   request,
                   documentId,
@@ -93,6 +137,9 @@ export function createReaderBootstrapEventStream(
             // The response may already have been aborted by the client.
           }
         }
+      }).finally(() => {
+        void activeReader?.cancel().catch(() => undefined);
+        activeReader = null;
       });
     },
     cancel() {

--- a/src/lib/server/reader/bootstrap-progress.ts
+++ b/src/lib/server/reader/bootstrap-progress.ts
@@ -1,0 +1,41 @@
+import type { ComputeOperation, PdfLayoutResult } from '@/lib/server/compute-worker/protocol';
+import { pdfParseSnapshotFromWorkerState } from '@/lib/server/pdf-parse/snapshot';
+import type { ReaderBootstrapResolution } from './bootstrap';
+
+/** Project an already-authorized worker snapshot without re-reading the database or worker. */
+export function resolvePdfOperationReadiness(
+  operation: ComputeOperation<PdfLayoutResult>,
+): ReaderBootstrapResolution | null {
+  const snapshot = pdfParseSnapshotFromWorkerState(operation);
+  if (snapshot.parseStatus === 'ready') return null;
+  if (snapshot.parseStatus === 'failed') {
+    return {
+      result: {
+        status: 'error',
+        message: snapshot.error || 'PDF structure could not be prepared.',
+        retryable: true,
+      },
+    };
+  }
+  const progress = snapshot.parseProgress;
+  return {
+    result: {
+      status: 'pending',
+      progress: {
+        kind: 'pdf-parse',
+        phase: snapshot.parseStatus === 'pending'
+          ? 'queued'
+          : progress?.phase === 'download_model'
+            ? 'downloading-model'
+            : progress?.phase === 'merge' ? 'merging' : 'parsing',
+        pagesParsed: Math.max(0, Number(progress?.pagesParsed ?? 0)),
+        totalPages: Math.max(0, Number(progress?.totalPages ?? 0)),
+        ...(progress?.phase === 'download_model' ? {
+          downloadedBytes: Math.max(0, Number(progress.downloadedBytes ?? 0)),
+          totalBytes: Math.max(0, Number(progress.totalBytes ?? 0)),
+        } : {}),
+      },
+    },
+    operationId: operation.opId,
+  };
+}

--- a/src/lib/server/reader/bootstrap.ts
+++ b/src/lib/server/reader/bootstrap.ts
@@ -19,7 +19,6 @@ import type { BaseDocument } from '@/types/documents';
 import type { DocumentProgressRecord } from '@/types/user-state';
 import type { ParsedPdfDocument } from '@/types/parsed-pdf';
 import type {
-  ReaderBootstrapProgress,
   ReaderBootstrapResult,
   ReaderPayload,
 } from '@/types/reader-bootstrap';
@@ -36,8 +35,6 @@ import {
   isComputeWorkerAvailable,
 } from '@/lib/server/compute-worker/client';
 import type {
-  ComputeOperation,
-  PdfLayoutResult,
   TtsPlaybackPlanResult,
 } from '@/lib/server/compute-worker/protocol';
 import {
@@ -48,7 +45,6 @@ import {
 } from '@/lib/server/pdf-parse/operation';
 import {
   isCurrentPdfParseOperationAuthoritative,
-  pdfParseSnapshotFromWorkerState,
 } from '@/lib/server/pdf-parse/snapshot';
 import {
   checkJobRate,
@@ -72,6 +68,7 @@ import {
   type PreferenceNormalizationContext,
 } from '@/lib/server/user/preferences-normalize';
 import { nowTimestampMs } from '@/lib/shared/timestamps';
+import { resolvePdfOperationReadiness } from './bootstrap-progress';
 
 type DocumentRow = {
   id: string;
@@ -134,57 +131,6 @@ function toProgress(row: {
   return null;
 }
 
-function pendingPdfProgress(
-  status: 'pending' | 'running',
-  progress: {
-    phase: 'download_model' | 'infer' | 'merge';
-    pagesParsed: number;
-    totalPages: number;
-    downloadedBytes?: number;
-    totalBytes?: number;
-  } | null,
-): ReaderBootstrapProgress {
-  return {
-    kind: 'pdf-parse',
-    phase: status === 'pending'
-      ? 'queued'
-      : progress?.phase === 'download_model'
-        ? 'downloading-model'
-        : progress?.phase === 'merge' ? 'merging' : 'parsing',
-    pagesParsed: Math.max(0, Number(progress?.pagesParsed ?? 0)),
-    totalPages: Math.max(0, Number(progress?.totalPages ?? 0)),
-    ...(progress?.phase === 'download_model' ? {
-      downloadedBytes: Math.max(0, Number(progress.downloadedBytes ?? 0)),
-      totalBytes: Math.max(0, Number(progress.totalBytes ?? 0)),
-    } : {}),
-  };
-}
-
-function resolvePdfOperationReadiness(
-  operation: ComputeOperation<PdfLayoutResult>,
-): ReaderBootstrapResolution | null {
-  const snapshot = pdfParseSnapshotFromWorkerState(operation);
-  if (snapshot.parseStatus === 'ready') return null;
-  if (snapshot.parseStatus === 'failed') {
-    return {
-      result: {
-        status: 'error',
-        message: snapshot.error || 'PDF structure could not be prepared.',
-        retryable: true,
-      },
-    };
-  }
-  return {
-    result: {
-      status: 'pending',
-      progress: pendingPdfProgress(
-        snapshot.parseStatus === 'running' ? 'running' : 'pending',
-        snapshot.parseProgress,
-      ),
-    },
-    operationId: operation.opId,
-  };
-}
 
 async function ensurePdfReady(
   documentId: string,

--- a/tests/e2e/playback-controls.spec.ts
+++ b/tests/e2e/playback-controls.spec.ts
@@ -82,8 +82,11 @@ async function verifyEpubPlayback(page: Page) {
   const position = page.getByRole('slider', { name: 'Playback position', exact: true });
   const initialViewportHeading = page.frameLocator('iframe').getByRole('heading').first();
   await expect(initialViewportHeading).toBeInViewport();
+  // The EPUB rendition and its asynchronous duration projection become ready
+  // independently. Wait for the same required value instead of sampling once.
+  await expect.poll(async () => Number(await position.getAttribute('max')))
+    .toBeGreaterThan(0);
   const documentDuration = Number(await position.getAttribute('max'));
-  expect(documentDuration).toBeGreaterThan(0);
 
   const sessionResponsePromise = page.waitForResponse((response) => (
     response.request().method() === 'POST'

--- a/tests/unit/playback-cache-clear-route.vitest.spec.ts
+++ b/tests/unit/playback-cache-clear-route.vitest.spec.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({ clear: vi.fn(), warn: vi.fn() }));
+vi.mock('@/lib/server/tts/segments-auth', () => ({
+  resolveSegmentDocumentScope: async () => ({ storageUserId: 'user-1', documentVersion: 1, readerType: 'epub' }),
+}));
+vi.mock('@/lib/server/compute-worker/client', () => ({
+  isComputeWorkerAvailable: () => true,
+  ComputeWorkerClient: class { clearTtsPlaybackScope = mocks.clear; },
+}));
+vi.mock('@/lib/server/logger', () => ({
+  createRequestLogger: () => ({ logger: { warn: mocks.warn, error: vi.fn() } }),
+}));
+
+import { POST } from '@/app/api/tts/segments/clear/route';
+
+const request = () => new NextRequest('http://localhost/api/tts/segments/clear', {
+  method: 'POST', body: JSON.stringify({ documentId: 'doc-1' }),
+});
+
+describe('cache clear confirmation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('waits for cleanup completion before reporting success', async () => {
+    let finish!: (value: unknown) => void;
+    mocks.clear.mockReturnValueOnce(new Promise((resolve) => { finish = resolve; }));
+    let settled = false;
+    const response = POST(request()).then((value) => { settled = true; return value; });
+    await vi.waitFor(() => expect(mocks.clear).toHaveBeenCalledOnce());
+    expect(settled).toBe(false);
+    expect(mocks.clear.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+    finish({ deletedAudioObjects: 2, deletedSidecarObjects: 2, deletedPlanObjects: 1,
+      deletedExportObjects: 0, invalidatedPlaybackSessions: 1, invalidatedJobOperations: 2 });
+    const result = await response;
+    expect(result.status).toBe(200);
+    expect(await result.json()).toMatchObject({ deletedPlaybackObjects: 5 });
+  });
+
+  test('reports an uncertain timeout instead of falsely confirming or retrying deletion', async () => {
+    mocks.clear.mockRejectedValueOnce(new DOMException('Timed out', 'TimeoutError'));
+    const result = await POST(request());
+    expect(result.status).toBe(504);
+    expect((await result.json()).error).toContain('cache may already be reset');
+    expect(mocks.clear).toHaveBeenCalledOnce();
+    expect(mocks.warn).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/playback-media-events.vitest.spec.ts
+++ b/tests/unit/playback-media-events.vitest.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test, vi } from 'vitest';
+import { installPlaybackMediaEvents } from '@/lib/client/tts/playback-media-events';
+
+describe('playback media event policy', () => {
+  test('tears down the current stream on ended even after play intent is cleared', () => {
+    const audio = { paused: false } as HTMLAudioElement;
+    const onEnded = vi.fn();
+    installPlaybackMediaEvents({
+      audio,
+      audioSpeed: 1,
+      isCurrent: () => true,
+      isPlaying: () => false,
+      shouldRecoverEnd: () => false,
+      onPause: vi.fn(),
+      onBuffering: vi.fn(),
+      onRecover: vi.fn(),
+      onEnded,
+      onTime: vi.fn(),
+      onPlaying: vi.fn(),
+    });
+    audio.onended?.(new Event('ended'));
+    expect(onEnded).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/playback-recovery.vitest.spec.ts
+++ b/tests/unit/playback-recovery.vitest.spec.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createPlaybackRecovery } from '@/lib/client/tts/playback-recovery';
+
+describe('same-session media recovery', () => {
+  beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(0); });
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+  function fixture() {
+    let current = true;
+    let time = 20;
+    const readyTarget = vi.fn<() => { ordinal: number; time: number } | null>(() => ({ ordinal: 12, time }));
+    const reconnect = vi.fn();
+    const onExhausted = vi.fn(() => { current = false; });
+    const recovery = createPlaybackRecovery({
+      isCurrent: () => current, currentTime: () => time, readyTarget, reconnect, onExhausted,
+    });
+    return { recovery, readyTarget, reconnect, onExhausted,
+      setCurrent: (value: boolean) => { current = value; }, setTime: (value: number) => { time = value; } };
+  }
+  test('does nothing while the media clock advances', () => {
+    const f = fixture();
+    for (let i = 1; i <= 30; i++) { f.setTime(20 + i); vi.advanceTimersByTime(1_000); }
+    expect(f.readyTarget).not.toHaveBeenCalled();
+    expect(f.reconnect).not.toHaveBeenCalled();
+  });
+  test('waits for generated runway, then reconnects at the preserved cursor', () => {
+    const f = fixture();
+    f.readyTarget.mockReturnValue(null);
+    vi.advanceTimersByTime(20_000);
+    expect(f.reconnect).not.toHaveBeenCalled();
+    f.readyTarget.mockReturnValue({ ordinal: 12, time: 20 });
+    vi.advanceTimersByTime(1_000);
+    expect(f.reconnect).toHaveBeenCalledExactlyOnceWith({ ordinal: 12, time: 20 });
+  });
+  test('bounds reconnects without progress and supports a deliberate later resume', () => {
+    const f = fixture();
+    vi.advanceTimersByTime(30_000);
+    expect(f.reconnect).toHaveBeenCalledTimes(2);
+    expect(f.onExhausted).toHaveBeenCalledTimes(1);
+    f.setCurrent(true);
+    vi.advanceTimersByTime(5_000);
+    expect(f.reconnect).toHaveBeenCalledTimes(3);
+  });
+  test('pause and teardown prevent recovery; real progress resets its budget', () => {
+    const f = fixture();
+    vi.advanceTimersByTime(5_000);
+    f.setTime(22);
+    vi.advanceTimersByTime(1_000);
+    vi.advanceTimersByTime(5_000);
+    expect(f.reconnect).toHaveBeenCalledTimes(2);
+    expect(f.onExhausted).not.toHaveBeenCalled();
+    f.setCurrent(false);
+    vi.advanceTimersByTime(30_000);
+    expect(f.reconnect).toHaveBeenCalledTimes(2);
+    f.recovery.stop();
+    f.setCurrent(true);
+    vi.advanceTimersByTime(30_000);
+    f.recovery.check();
+    expect(f.reconnect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/playback-refresh.vitest.spec.ts
+++ b/tests/unit/playback-refresh.vitest.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
-import { createCoalescedPlaybackRefresh, createPlaybackTimelineLoader } from '@/lib/client/tts/playback-refresh';
+import { createCoalescedPlaybackRefresh, createPlaybackTimelineLoader, createPlaybackOperationSubscription } from '@/lib/client/tts/playback-refresh';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -8,6 +8,29 @@ function deferred<T>() {
 }
 
 describe('playback read-model delivery under network delay', () => {
+  test('follows refill operations once and ignores late events after replacement or pause', () => {
+    const callbacks = new Map<string, (snapshot: string) => void>();
+    const close = vi.fn();
+    const subscribe = vi.fn((id: string, onSnapshot: (snapshot: string) => void) => {
+      callbacks.set(id, onSnapshot);
+      return close;
+    });
+    const onSnapshot = vi.fn();
+    const events = createPlaybackOperationSubscription({ subscribe, onSnapshot });
+    events.update('first');
+    events.update('first');
+    callbacks.get('first')!('initial timing');
+    events.update('refill');
+    callbacks.get('first')!('stale model download');
+    callbacks.get('refill')!('new exact timing');
+    events.stop();
+    callbacks.get('refill')!('late after pause');
+    events.update('after-stop');
+    expect(subscribe).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenCalledTimes(2);
+    expect(onSnapshot.mock.calls.flat()).toEqual(['initial timing', 'new exact timing']);
+  });
+
   test('shares slow timeline reads and fetches exact timing on the next refresh', async () => {
     const slow = deferred<string>();
     const session = { timelineUrl: '/timeline' };

--- a/tests/unit/playback-refresh.vitest.spec.ts
+++ b/tests/unit/playback-refresh.vitest.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createCoalescedPlaybackRefresh, createPlaybackTimelineLoader } from '@/lib/client/tts/playback-refresh';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+describe('playback read-model delivery under network delay', () => {
+  test('shares slow timeline reads and fetches exact timing on the next refresh', async () => {
+    const slow = deferred<string>();
+    const session = { timelineUrl: '/timeline' };
+    const load = vi.fn().mockReturnValueOnce(slow.promise).mockResolvedValue('exact');
+    const apply = vi.fn();
+    const loader = createPlaybackTimelineLoader({ load, apply, getRunId: () => 1, getSession: () => session });
+    const first = loader.refresh('/timeline');
+    for (let i = 0; i < 20; i++) expect(loader.refresh('/timeline')).toBe(first);
+    expect(load).toHaveBeenCalledTimes(1);
+    slow.resolve('proportional');
+    await first;
+    await loader.refresh('/timeline');
+    expect(apply.mock.calls.map(([value]) => value)).toEqual(['proportional', 'exact']);
+  });
+
+  test('cannot overwrite a new run with a late response, even if fetch ignores abort', async () => {
+    const slow = deferred<string>();
+    let runId = 1;
+    const session = { timelineUrl: '/timeline' };
+    const load = vi.fn().mockReturnValueOnce(slow.promise).mockResolvedValue('new-exact');
+    const apply = vi.fn();
+    const loader = createPlaybackTimelineLoader({ load, apply, getRunId: () => runId, getSession: () => session });
+    const old = loader.refresh('/timeline');
+    runId = 2;
+    await loader.refresh('/timeline');
+    expect(load.mock.calls[0][1].aborted).toBe(true);
+    slow.resolve('old-proportional');
+    await old;
+    expect(apply.mock.calls.map(([value]) => value)).toEqual(['new-exact']);
+  });
+
+  test('reset prevents pending reads from restoring a cleared timeline', async () => {
+    const slow = deferred<string>();
+    const session = { timelineUrl: '/timeline' };
+    const apply = vi.fn();
+    const loader = createPlaybackTimelineLoader({
+      load: () => slow.promise, apply, getRunId: () => 1, getSession: () => session,
+    });
+    const read = loader.refresh('/timeline');
+    loader.reset();
+    slow.resolve('stale');
+    await read;
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  test('does not reuse a request whose foreground subscription has already aborted', async () => {
+    const slow = deferred<string>();
+    const session = { timelineUrl: '/timeline' };
+    const load = vi.fn().mockReturnValueOnce(slow.promise).mockResolvedValue('resumed');
+    const apply = vi.fn();
+    const loader = createPlaybackTimelineLoader({ load, apply, getRunId: () => 1, getSession: () => session });
+    const controller = new AbortController();
+    const old = loader.refresh('/timeline', controller.signal);
+    controller.abort();
+    await loader.refresh('/timeline');
+    slow.resolve('aborted');
+    await old;
+    expect(apply.mock.calls.map(([value]) => value)).toEqual(['resumed']);
+  });
+
+  test('coalesces SSE bursts but preserves a trailing exact-timing refresh', async () => {
+    const first = deferred<void>();
+    const second = deferred<void>();
+    const load = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const refresh = createCoalescedPlaybackRefresh(load);
+    refresh.request();
+    for (let i = 0; i < 20; i++) refresh.request();
+    expect(load).toHaveBeenCalledTimes(1);
+    first.resolve();
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+    second.resolve();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(load).toHaveBeenCalledTimes(2);
+    refresh.stop();
+  });
+
+  test('stopping aborts the active refresh and discards queued events', async () => {
+    const slow = deferred<void>();
+    const load = vi.fn(() => slow.promise);
+    const refresh = createCoalescedPlaybackRefresh(load);
+    refresh.request();
+    refresh.request();
+    refresh.stop();
+    expect((load.mock.calls[0] as unknown as [AbortSignal])[0].aborted).toBe(true);
+    slow.resolve();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    refresh.request();
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/playback-refresh.vitest.spec.ts
+++ b/tests/unit/playback-refresh.vitest.spec.ts
@@ -91,6 +91,46 @@ describe('playback read-model delivery under network delay', () => {
     expect(apply.mock.calls.map(([value]) => value)).toEqual(['resumed']);
   });
 
+  test('follows an unscoped timing-heal read with the foreground abortable refresh', async () => {
+    const slow = deferred<string>();
+    const foreground = deferred<string>();
+    const session = { timelineUrl: '/timeline' };
+    const load = vi.fn().mockReturnValueOnce(slow.promise).mockReturnValueOnce(foreground.promise);
+    const apply = vi.fn();
+    const loader = createPlaybackTimelineLoader({ load, apply, getRunId: () => 1, getSession: () => session });
+    const timingHeal = loader.refresh('/timeline');
+    const controller = new AbortController();
+    const exact = loader.refresh('/timeline', controller.signal);
+    expect(exact).not.toBe(timingHeal);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(load.mock.calls[0][1].aborted).toBe(false);
+    slow.resolve('proportional');
+    await timingHeal;
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+    controller.abort();
+    expect(load.mock.calls[1][1].aborted).toBe(true);
+    foreground.resolve('exact');
+    await exact;
+    expect(apply.mock.calls.map(([value]) => value)).toEqual(['proportional']);
+  });
+
+  test('foreground stop cancels a trailing refresh before an unscoped read settles', async () => {
+    const slow = deferred<string>();
+    const session = { timelineUrl: '/timeline' };
+    const load = vi.fn().mockReturnValue(slow.promise);
+    const loader = createPlaybackTimelineLoader({
+      load, apply: vi.fn(), getRunId: () => 1, getSession: () => session,
+    });
+    const timingHeal = loader.refresh('/timeline');
+    const controller = new AbortController();
+    const exact = loader.refresh('/timeline', controller.signal);
+    controller.abort(new DOMException('Stopped', 'AbortError'));
+    await expect(exact).rejects.toMatchObject({ name: 'AbortError' });
+    slow.resolve('proportional');
+    await timingHeal;
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
   test('coalesces SSE bursts but preserves a trailing exact-timing refresh', async () => {
     const first = deferred<void>();
     const second = deferred<void>();

--- a/tests/unit/reader-bootstrap-events.vitest.spec.ts
+++ b/tests/unit/reader-bootstrap-events.vitest.spec.ts
@@ -30,6 +30,41 @@ describe('reader bootstrap aggregate event stream', () => {
     hoisted.resolveReaderBootstrapState.mockReset();
   });
 
+  test('forwards download progress and keepalives without a readiness round trip', async () => {
+    const initial: ReaderBootstrapResolution = {
+      result: { status: 'pending', progress: {
+        kind: 'pdf-parse', phase: 'queued', pagesParsed: 0, totalPages: 0,
+      } },
+      operationId: 'parse-op',
+    };
+    const snapshot = (opId: string, downloadedBytes: number) => (
+      `event: snapshot\ndata: ${JSON.stringify({ snapshot: {
+        opId, status: 'running', progress: {
+          phase: 'download_model', pagesParsed: 0, totalPages: 0,
+          downloadedBytes, totalBytes: 100,
+        },
+      } })}\n\n`
+    );
+    hoisted.openOperationEvents.mockResolvedValue(new Response(
+      snapshot('parse-op', 10) + ': keepalive\n\n'
+      + snapshot('wrong-op', 75) + 'event: snapshot\ndata: invalid\n\n'
+      + snapshot('parse-op', 90),
+    ));
+    // An accidentally reintroduced resolver call must not delay progress.
+    hoisted.resolveReaderBootstrapState.mockImplementation(() => new Promise(() => undefined));
+    const { createReaderBootstrapEventStream } = await import('@/lib/server/reader/bootstrap-events');
+    const body = await new Response(createReaderBootstrapEventStream(
+      new NextRequest('http://localhost/events'), 'doc-1', initial,
+    )).text();
+
+    expect(body).toContain(': keepalive\n\n');
+    const snapshots = body.split('\n').filter((line) => line.startsWith('data: '))
+      .map((line) => JSON.parse(line.slice(6)));
+    expect(snapshots.map((value) => value.progress.downloadedBytes)).toEqual([undefined, 10, 90]);
+    expect(snapshots[2].progress.phase).toBe('downloading-model');
+    expect(hoisted.resolveReaderBootstrapState).not.toHaveBeenCalled();
+  });
+
   test('moves from PDF parse observation to plan observation and emits full snapshots', async () => {
     const initial: ReaderBootstrapResolution = {
       result: {

--- a/tests/unit/server-state-architecture.vitest.spec.ts
+++ b/tests/unit/server-state-architecture.vitest.spec.ts
@@ -236,10 +236,11 @@ describe('server-state architecture', () => {
     ].sort());
     expect(workerRoutes).not.toContain('/v1/tts-playback/cache/reset');
     expect(workerRoutes).toContain('await playbackStorage.artifacts.incrementScopeEpoch(scope, now)');
-    expect(workerRoutes).toContain('await playbackStorage.sessions.cancelSessionsForScope(scope, now)');
+    expect(workerRoutes).toContain("await timed('cancel_sessions'");
+    expect(workerRoutes).toContain('playbackStorage.sessions.cancelSessionsForScope(scope, now)');
     expect(workerRoutes).toContain('readModel.invalidateSidecarsForScope(scope)');
-    expect(workerRoutes).toContain('await invalidatePlaybackOperationsForScope({');
-    expect(workerRoutes).toContain('await clearTtsPlaybackArtifacts({');
+    expect(workerRoutes).toContain("await timed('invalidate_operations', () => invalidatePlaybackOperationsForScope({");
+    expect(workerRoutes).toContain("await timed('delete_objects', () => clearTtsPlaybackArtifacts({");
     const compositionRoot = source('packages/compute-worker/src/api/routes.ts');
     expect(compositionRoot).toContain('registerPlaybackAudioRoutes(context, playbackReadModel, playbackController)');
     expect(compositionRoot).not.toContain('app.get(');

--- a/tests/unit/server-state-architecture.vitest.spec.ts
+++ b/tests/unit/server-state-architecture.vitest.spec.ts
@@ -230,6 +230,7 @@ describe('server-state architecture', () => {
       'POST /v1/tts-playback/plans/clear',
       'POST /v1/tts-playback/plans/jobs',
       'POST /v1/tts-playback/sessions/jobs',
+      'POST /v1/tts-playback/sessions/prepare',
       'POST /v1/tts-playback/sessions/resolve',
       'POST /v1/user-storage/cleanup',
       'PUT /v1/tts-playback/sessions/:sessionId/cursor',
@@ -491,7 +492,7 @@ describe('server-state architecture', () => {
     expect(workerRoutes).toContain("/v1/tts-playback/sessions/resolve");
     expect(workerRoutes).not.toContain("/v1/tts-playback/:sessionId/audio");
     expect(workerRoutes).not.toContain("/v1/tts-playback-plans/operations");
-    expect(workerRoutes).toContain('Readable.from(streamRange())');
+    expect(workerRoutes).toContain("Readable.from(streamRange(), { objectMode: false, highWaterMark: 64 * 1024 })");
     // The audio stream is seekable (range-capable + finite Content-Length) so the
     // browser honors post-generation playbackRate, including on Safari.
     expect(workerRoutes).toContain("reply.header('Accept-Ranges', 'bytes')");

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -1713,3 +1713,33 @@ Follow-up investigation: rapid cancellation before the session-creation response
 arrives produced aborted HTTP requests alongside queued synthesis in local logs.
 Verify cancellation ownership across that boundary separately; this patch does
 not change session-creation cancellation semantics.
+
+### Step 28 — Playback cancellation and stalled-stream recovery
+
+The production playback follow-up exposed three independent failure modes:
+
+- Live sessions are now prepared inactive and enqueue no synthesis. The browser
+  activates the exact session incarnation only after receiving and accepting the
+  preparation response. Abandoned requests therefore remain inert, and a delayed
+  pause/start from a replaced incarnation is rejected.
+- Refill identity includes the predecessor generation run. Concurrent cursor and
+  audio signals still collapse onto one idempotent job, while a later visit to the
+  same cursor cannot reuse a partial job that stopped successfully on pause.
+- The cursor heartbeat returns the current worker operation and retargets the
+  operation-scoped SSE subscription when refill begins. This preserves exact-word
+  timing and readiness delivery without adding another polling loop.
+- A five-second local media-clock watchdog reconnects only when the existing SSE
+  read model already proves enough contiguous cached audio is ready. It reopens
+  the same canonical session at the current ordinal, preserving the cache and
+  projected document time. Two unsuccessful reconnects pause with an actionable
+  error instead of spinning or creating replacement sessions.
+- The worker audio response uses byte-mode backpressure with a 64 KiB high-water
+  mark; it no longer permits Node to queue sixteen whole segment buffers merely
+  because an async generator yields Buffer objects.
+
+Focused coverage locks cancellation before activation, incarnation ordering,
+same-cursor refill identity, SSE operation replacement, and bounded same-session
+media recovery. Local verification passed 133 Vitest files / 669 tests, application
+and worker type checks, the production build and bundle/boundary guards, and the
+complete 24-case Chromium/WebKit matrix with both true-audio journeys. Production
+network validation remains the final deployment check for this step.

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -249,11 +249,13 @@ or another worker is discovered.
 1. The client ensures the canonical worker plan is loaded.
 2. The client maps the selected/highlighted UI state to exactly one worker-plan
    ordinal from that plan.
-3. The client asks the Next proxy for a playback session with that ordinal.
-4. The compute worker validates the ordinal against the immutable plan and uses it
-   as `generationStartOrdinal`.
-5. The worker writes the session record and cursor key with plain `put`.
-6. A JetStream operation is queued for generation.
+3. The client asks the Next proxy to prepare a playback session with that ordinal.
+4. The compute worker validates the ordinal against the immutable plan, writes an
+   inactive session record, and returns its instance identity without queuing generation.
+5. After the browser accepts the response, it activates that exact session instance
+   by writing the cursor and active playback intent.
+6. Activation queues a JetStream operation and uses the ordinal as
+   `generationStartOrdinal`.
 7. The generation job patches non-cursor session fields such as status and
    generation start with plain `put`.
 

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -309,13 +309,14 @@ seeking can target ungenerated regions without cutting a segment in half.
 Readiness is derived from sidecars:
 
 - Single-ordinal reads are used by the stream wait loop.
-- Timeline and seek-layout readers use a bounded scan from the start of the plan
-  through `max(highestCachedCompletedOrdinal, cursorOrdinal) + 64`.
+- Timeline and seek-layout readers list existing sidecars for the exact
+  user/document/version/settings prefix and share concurrent catalogue reads.
+  They do not probe ungenerated ordinals before a deep cursor.
 - Reads are batched in groups of 32.
-- Completed sidecars are cached forever within an LRU-ish scope cache capped at 8
-  document/settings scopes.
-- The non-hot `/segments` listing reads all plan ordinals so it can return the full
-  completed set.
+- Completed sidecars with exact alignment are cached within an LRU-ish scope
+  cache capped at 8 document/settings scopes; cache epochs invalidate cleared data.
+- The default `/segments` listing returns the complete discovered cached set;
+  explicit-window requests still read only their requested ordinal window.
 
 When audio is ready before exact alignment, the timeline explicitly labels its
 word schedule as `proportional`. The client may use that schedule immediately,
@@ -1656,3 +1657,59 @@ Playwright matrix with both real playback journeys. A subsequent deployed cold-m
 walkthrough should confirm bounded model progress, uninterrupted audio refill,
 prompt pause/seek cancellation, and exact timing replacement after the model
 becomes ready.
+
+### Step 27 — Production progress and cleanup latency
+
+The production follow-up found delivery-path work that grows with network latency
+and accumulated data, independently of inference CPU load:
+
+- A fresh operation SSE subscription replays the latest event for its exact
+  subject before following new events. This closes the initial-state-read /
+  subscription race that could permanently miss completion. Cursor-based
+  reconnects retain sequence replay. Older snapshots cannot regress the initial
+  state, and immediate terminal replay also tears down its consumer correctly.
+- Reader bootstrap now projects running PDF/download progress from the authorized
+  worker SSE snapshot. Full readiness resolution happens only at operation
+  boundaries; upstream keepalives are forwarded instead of discarded.
+- Exact word timing is persisted in segment sidecars. SSE signals a change, then
+  the browser fetches the timeline; it does not receive a separate event per word.
+  Foreground refresh bursts share active reads and retain a trailing refresh.
+  Timeline reads are scoped to their playback run/session, and reset aborts old
+  requests so late responses cannot restore stale timing.
+- Whole-document timeline/duration reads list existing sidecars for the exact
+  user/document/version/settings scope, rather than probing every ordinal from
+  zero to a deep cursor. Concurrent reads share an in-flight collection. Exact
+  sidecars stay cached across chapters; proportional sidecars are re-read until
+  exact timing is available. This preserves the complete generated-cache view.
+- Playback job startup uses the same scoped catalogue to discover completed
+  segments. It no longer probes every ungenerated segment in the entire book
+  before starting or resuming synthesis. Epoch and plan-membership checks still
+  exclude cleared or unrelated entries.
+- Cache cleanup batches remote operation reads and invalidations, filters by
+  document/version/settings before session ownership reads, and shares repeated
+  ownership lookups. Clearing one document must not invalidate another document's
+  live jobs merely because they belong to the same user.
+- Cache reset still waits for physical cleanup before reporting success. The
+  interactive app-to-worker request has a 45-second confirmation deadline and
+  the browser a 60-second deadline. A timeout reports uncertain completion, not
+  success, and does not automatically retry destructive cleanup. Worker phase
+  timings distinguish session cancellation, operation invalidation, and object
+  deletion on the next production run.
+
+Regression coverage includes a blocked readiness resolver, slow/coalesced reads,
+late old-run responses, a 10,000-segment book with sparse cached audio, scoped
+cleanup, bounded NATS concurrency, and an uncertain cleanup confirmation.
+Production validation remains required for actual Vercel/Railway latency.
+
+Local verification: 132 Vitest files / 662 tests passed, application and worker
+type checks passed, production build and boundary/route-error/bundle guards
+passed, and the final full Chromium/WebKit matrix passed all 24 cases with both
+real-audio journeys. The EPUB test now waits for its asynchronously loaded
+positive duration rather than sampling it once when the rendition first appears.
+No playback assertions, browser projects, or worker-concurrency settings were
+removed. Temporary stdout-only diagnostic configuration was removed afterward.
+
+Follow-up investigation: rapid cancellation before the session-creation response
+arrives produced aborted HTTP requests alongside queued synthesis in local logs.
+Verify cancellation ownership across that boundary separately; this patch does
+not change session-creation cancellation semantics.


### PR DESCRIPTION
## Summary\n\n- prevent missed worker progress by replaying the latest NATS operation snapshot and preserving cursor-based reconnect ordering\n- project PDF/model progress from SSE while coalescing timeline and seek-layout refreshes\n- replace whole-book ordinal probing with scoped cached-sidecar discovery and batch cache cleanup work\n- prepare live playback sessions without enqueueing synthesis, then activate only the exact session instance accepted by the browser\n- give same-cursor refill attempts distinct idempotency identities while still collapsing concurrent triggers\n- retarget playback SSE when refill moves to a successor operation\n- recover dead media connections inside the same canonical session and cache, with two bounded retries and preserved document time\n- use byte-mode audio backpressure with a 64 KiB high-water mark\n- document the production findings and resulting contracts in the v5 playback architecture\n\n## Verification\n\n- pnpm test: 133 files, 669 tests passed\n- application and compute-worker TypeScript checks passed\n- pnpm build passed\n- bundle and compute-boundary guards passed\n- full Playwright matrix passed: 24 Chromium/WebKit cases in 1.8 minutes, including both true-audio journeys\n\n## Deployment follow-up\n\nProduction network validation on the Vercel/Railway stack remains the final confirmation for long-latency playback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TTS playback session preparation and activation.
  * Added stalled-stream recovery with bounded reconnection attempts.
  * Playback can be canceled while audio is loading.
  * Improved timeline and cached-segment loading for sparse documents.
  * PDF reader progress now updates more directly during parsing.

* **Bug Fixes**
  * Prevented stale sessions, cursor updates, and event data from overwriting current playback.
  * Added clearer timeout handling for cache cleanup.

* **Documentation**
  * Updated playback architecture and recovery documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->