### PR TITLE
refactor(playback): simplify client lifecycle and seek readiness

### DIFF
--- a/src/contexts/TTSContext.tsx
+++ b/src/contexts/TTSContext.tsx
@@ -43,6 +43,7 @@ import { useTtsPlanController } from '@/hooks/audio/useTtsPlanController';
 import { useTtsPlaybackModel } from '@/hooks/audio/useTtsPlaybackModel';
 import { useTtsPlaybackSettings } from '@/hooks/audio/useTtsPlaybackSettings';
 import type { TtsPlaybackSeekLayout } from '@/lib/client/api/tts';
+import { isPlaybackPhaseProcessing } from '@/lib/client/tts/playback-control';
 import {
   pdfLocatorPage,
   resolveDocumentAnchorSelectionOrdinal,
@@ -209,7 +210,7 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
    */
   const [isPlaying, setIsPlaying] = useState(false);
   const [isEPUB, setIsEPUB] = useState(false);
-  const [isProcessing, setIsProcessing] = useState(false);
+  const [isInteractionProcessing, setIsProcessing] = useState(false);
 
   /**
    * Resolved reader type for playback/session scoping. Consumers use this to
@@ -413,7 +414,6 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
     selectedOrdinalRef,
     playbackRunIdRef,
     setIsPlaying,
-    setIsProcessing,
     setCurrDocPage,
     syncPlaybackLocator,
     setSelectedOrdinal,
@@ -539,11 +539,8 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
    * Stops the current audio playback and resets all state
    */
   const stop = useCallback(() => {
-    // Cancel any ongoing request
-    invalidatePlaybackRun();
     abortAudio();
     setIsPlaying(false);
-    publishPlaybackTimeSec(0, { force: true });
     resetPlaybackPlan();
     playbackAnchorRef.current = null;
     setPlaybackAnchor(null);
@@ -554,7 +551,7 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
     sentenceAlignmentCacheRef.current.clear();
     setCurrentSentenceAlignment(undefined);
     setCurrentWordIndex(null);
-  }, [abortAudio, invalidatePlaybackRun, publishPlaybackTimeSec, resetPlaybackPlan]);
+  }, [abortAudio, resetPlaybackPlan]);
 
   const initializeReaderSession = useCallback((input: {
     readerType: ReaderType;
@@ -625,6 +622,8 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
     reacquirePlaybackPlan,
   });
 
+  const isProcessing = isInteractionProcessing
+    || isPlaybackPhaseProcessing(isPlaying, playbackPhase);
 
   /**
    * Provides the TTS context value to child components

--- a/src/contexts/TTSContext.tsx
+++ b/src/contexts/TTSContext.tsx
@@ -393,9 +393,8 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
   const {
     playbackPhase,
     playbackTimeSec,
-    publishPlaybackTimeSec,
     abortAudio: controllerAbortAudio,
-    cancelSeekResync: controllerCancelSeekResync,
+    cancelPendingSeek: controllerCancelPendingSeek,
     invalidatePlaybackRun: controllerInvalidatePlaybackRun,
     pauseActivePlayback: controllerPauseActivePlayback,
     seekPlaybackTo: controllerSeekPlaybackTo,
@@ -424,7 +423,7 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
   });
 
   const abortAudio = controllerAbortAudio;
-  const cancelSeekResync = controllerCancelSeekResync;
+  const cancelPendingSeek = controllerCancelPendingSeek;
   const invalidatePlaybackRun = controllerInvalidatePlaybackRun;
   const pauseActivePlayback = controllerPauseActivePlayback;
   const seekPlaybackTo = controllerSeekPlaybackTo;
@@ -455,7 +454,7 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
     playbackSyncNavigationRef,
     resumeAfterLocationChangeRef,
     abortAudio,
-    cancelSeekResync,
+    cancelPendingSeek,
     invalidatePlaybackRun,
     pauseActivePlayback,
     seekPlaybackToOrdinal,

--- a/src/contexts/TTSContext.tsx
+++ b/src/contexts/TTSContext.tsx
@@ -391,7 +391,6 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
   ]);
 
   const {
-    unlockedAudioRef,
     playbackPhase,
     playbackTimeSec,
     publishPlaybackTimeSec,
@@ -528,12 +527,6 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
       }
     }
   }, [availableVoices, voice, configVoice, configModelPolicy]);
-
-  useEffect(() => {
-    if (unlockedAudioRef.current) {
-      unlockedAudioRef.current.playbackRate = audioSpeed;
-    }
-  }, [audioSpeed, unlockedAudioRef]);
 
   /**
    * Stops the current audio playback and resets all state

--- a/src/hooks/audio/usePlaybackAudioElement.ts
+++ b/src/hooks/audio/usePlaybackAudioElement.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+
+// Tiny silent WAV used to unlock HTML5 audio on iOS/Safari.
+const SILENT_WAV_DATA_URI =
+  'data:audio/wav;base64,UklGRkQDAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YSADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==';
+
+type UsePlaybackAudioElementInput = {
+  audioContext: AudioContext | null;
+  audioSpeed: number;
+};
+
+export function usePlaybackAudioElement(input: UsePlaybackAudioElementInput) {
+  const { audioContext, audioSpeed } = input;
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const unlockAttemptRef = useRef(0);
+
+  const ensureAudio = useCallback(() => {
+    let audio = audioRef.current;
+    if (audio) return audio;
+
+    audio = new Audio();
+    audio.preload = 'auto';
+    try {
+      audio.setAttribute('playsinline', 'true');
+    } catch {
+      // Some media shims do not implement DOM attributes.
+    }
+    audioRef.current = audio;
+    return audio;
+  }, []);
+
+  const clearAudioSource = useCallback(() => {
+    unlockAttemptRef.current += 1;
+    const audio = audioRef.current;
+    if (!audio) return;
+    try {
+      audio.pause();
+      audio.removeAttribute('src');
+      audio.load();
+    } catch {
+      // Ignore teardown errors from partially initialized browser media.
+    }
+  }, []);
+
+  const unlockAudioOnUserGesture = useCallback((preserveCurrentSource: boolean) => {
+    unlockAttemptRef.current += 1;
+    const attempt = unlockAttemptRef.current;
+
+    try {
+      void audioContext?.resume();
+    } catch {
+      // AudioContext unlocking is best-effort.
+    }
+
+    try {
+      const audio = ensureAudio();
+      if (preserveCurrentSource && audio.src && audio.src !== SILENT_WAV_DATA_URI) return;
+      audio.src = SILENT_WAV_DATA_URI;
+      audio.volume = 0;
+
+      const playResult = audio.play();
+      if (playResult && typeof playResult.then === 'function') {
+        void playResult
+          .then(() => {
+            if (unlockAttemptRef.current !== attempt) return;
+            try {
+              audio.pause();
+              audio.currentTime = 0;
+              audio.volume = 1;
+            } catch {
+              // The gesture already unlocked playback; resetting is best-effort.
+            }
+          })
+          .catch(() => undefined);
+      }
+    } catch {
+      // Browsers that reject the silent playback attempt can retry on Play.
+    }
+  }, [audioContext, ensureAudio]);
+
+  useEffect(() => {
+    if (audioRef.current) audioRef.current.playbackRate = audioSpeed;
+  }, [audioSpeed]);
+
+  useEffect(() => clearAudioSource, [clearAudioSource]);
+
+  return {
+    audioRef,
+    clearAudioSource,
+    ensureAudio,
+    unlockAudioOnUserGesture,
+  };
+}

--- a/src/hooks/audio/usePlaybackForegroundSync.ts
+++ b/src/hooks/audio/usePlaybackForegroundSync.ts
@@ -82,13 +82,15 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
           const session = playbackSessionRef.current;
           const headers = playbackRequestHeadersRef.current;
           const runId = playbackRunIdRef.current;
+          const events = playbackEventsRef.current;
           if (!session || !headers) continue;
           const updated = await postTtsPlaybackCursor(session.sessionId, nextOrdinal, headers, {
             sessionInstanceId: session.sessionInstanceId,
           }).catch(() => null);
           if (updated && runId === playbackRunIdRef.current
-            && playbackSessionRef.current === session) {
-            playbackEventsRef.current?.update(updated.workerOpId);
+            && playbackSessionRef.current === session
+            && playbackEventsRef.current === events) {
+            events?.update(updated.workerOpId);
           }
         }
       } finally {

--- a/src/hooks/audio/usePlaybackForegroundSync.ts
+++ b/src/hooks/audio/usePlaybackForegroundSync.ts
@@ -24,6 +24,11 @@ type UsePlaybackForegroundSyncInput = {
   setPlaybackSeekLayout: (layout: TtsPlaybackSeekLayout | null) => void;
 };
 
+type PlaybackOperationSubscription = {
+  update: (operationId: string | null) => void;
+  stop: () => void;
+};
+
 const MODEL_DOWNLOAD_TOAST_ID = 'tts-model-download';
 
 export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput) {
@@ -35,10 +40,12 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
     refreshPlaybackTimeline,
     setPlaybackSeekLayout,
   } = input;
-  const playbackEventsUnsubRef = useRef<(() => void) | null>(null);
+  const playbackEventsRef = useRef<PlaybackOperationSubscription | null>(null);
   const playbackCursorIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const playbackActivityWriteRef = useRef<Promise<void>>(Promise.resolve());
   const playbackRefreshRef = useRef<ReturnType<typeof createCoalescedPlaybackRefresh> | null>(null);
+  const playbackCursorWriteRef = useRef(false);
+  const pendingCursorOrdinalRef = useRef<number | null>(null);
 
   const setWorkerPlaybackActive = useCallback((playbackActive: boolean, requireAcknowledgement = false) => {
     const session = playbackSessionRef.current;
@@ -58,25 +65,63 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
     return write;
   }, [playbackCursorOrdinalRef, playbackRequestHeadersRef, playbackSessionRef]);
 
+  const updateWorkerPlaybackCursor = useCallback((ordinal?: number) => {
+    const requestedOrdinal = ordinal ?? playbackCursorOrdinalRef.current;
+    if (requestedOrdinal == null || !Number.isFinite(requestedOrdinal)) return;
+    const cursor = Math.max(0, Math.floor(requestedOrdinal));
+    playbackCursorOrdinalRef.current = cursor;
+    pendingCursorOrdinalRef.current = cursor;
+    if (playbackCursorWriteRef.current) return;
+
+    playbackCursorWriteRef.current = true;
+    void (async () => {
+      try {
+        while (pendingCursorOrdinalRef.current !== null) {
+          const nextOrdinal = pendingCursorOrdinalRef.current;
+          pendingCursorOrdinalRef.current = null;
+          const session = playbackSessionRef.current;
+          const headers = playbackRequestHeadersRef.current;
+          const runId = playbackRunIdRef.current;
+          if (!session || !headers) continue;
+          const updated = await postTtsPlaybackCursor(session.sessionId, nextOrdinal, headers, {
+            sessionInstanceId: session.sessionInstanceId,
+          }).catch(() => null);
+          if (updated && runId === playbackRunIdRef.current
+            && playbackSessionRef.current === session) {
+            playbackEventsRef.current?.update(updated.workerOpId);
+          }
+        }
+      } finally {
+        playbackCursorWriteRef.current = false;
+      }
+    })();
+  }, [
+    playbackCursorOrdinalRef,
+    playbackRequestHeadersRef,
+    playbackRunIdRef,
+    playbackSessionRef,
+  ]);
+
   const stopPlaybackForegroundSync = useCallback(() => {
     toast.dismiss(MODEL_DOWNLOAD_TOAST_ID);
     playbackRefreshRef.current?.stop();
     playbackRefreshRef.current = null;
+    pendingCursorOrdinalRef.current = null;
     if (playbackCursorIntervalRef.current) {
       clearInterval(playbackCursorIntervalRef.current);
       playbackCursorIntervalRef.current = null;
     }
-    if (playbackEventsUnsubRef.current) {
+    if (playbackEventsRef.current) {
       try {
-        playbackEventsUnsubRef.current();
+        playbackEventsRef.current.stop();
       } catch {
         // Ignore teardown errors.
       }
-      playbackEventsUnsubRef.current = null;
+      playbackEventsRef.current = null;
     }
   }, []);
 
-  const startPlaybackForegroundSync = useCallback((runId: number, headers: TTSRequestHeaders) => {
+  const startPlaybackForegroundSync = useCallback((runId: number) => {
     const activeSession = playbackSessionRef.current;
     if (!activeSession) return;
 
@@ -123,40 +168,24 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
         refresh.request();
       },
     });
-    playbackEventsUnsubRef.current = events.stop;
-
-    let writingCursor = false;
-    const writeCursor = async () => {
-      if (writingCursor) return;
-      const currentSession = playbackSessionRef.current;
-      if (!currentSession) return;
-      const cursorOrdinal = playbackCursorOrdinalRef.current;
-      if (cursorOrdinal == null) return;
-      const cursor = Math.max(0, cursorOrdinal);
-      writingCursor = true;
-      try {
-        const updated = await postTtsPlaybackCursor(currentSession.sessionId, cursor, headers, {
-          sessionInstanceId: currentSession.sessionInstanceId,
-        });
-        if (updated && runId === playbackRunIdRef.current && playbackSessionRef.current === activeSession) {
-          events.update(updated.workerOpId);
-        }
-      } finally {
-        writingCursor = false;
-      }
-    };
-    writeCursor();
+    playbackEventsRef.current = events;
+    updateWorkerPlaybackCursor();
     playbackCursorIntervalRef.current = setInterval(() => {
-      if (runId === playbackRunIdRef.current) writeCursor();
+      if (runId === playbackRunIdRef.current) updateWorkerPlaybackCursor();
     }, TTS_PLAYBACK_CURSOR_HEARTBEAT_MS);
   }, [
-    playbackCursorOrdinalRef,
     playbackRunIdRef,
     playbackSessionRef,
     refreshPlaybackTimeline,
     setPlaybackSeekLayout,
     stopPlaybackForegroundSync,
+    updateWorkerPlaybackCursor,
   ]);
 
-  return { setWorkerPlaybackActive, startPlaybackForegroundSync, stopPlaybackForegroundSync };
+  return {
+    setWorkerPlaybackActive,
+    startPlaybackForegroundSync,
+    stopPlaybackForegroundSync,
+    updateWorkerPlaybackCursor,
+  };
 }

--- a/src/hooks/audio/usePlaybackMediaResume.ts
+++ b/src/hooks/audio/usePlaybackMediaResume.ts
@@ -2,31 +2,28 @@
 
 import { useCallback, type MutableRefObject } from 'react';
 import { resumePlaybackMedia } from '@/lib/client/tts/playback-control';
-import type { TTSRequestHeaders } from '@/types/client';
 import type { TtsPlaybackPhase } from '@/types/tts';
 
 export function usePlaybackMediaResume(input: {
   audioSpeed: number;
   isPlayingRef: MutableRefObject<boolean>;
   playbackInFlightRef: MutableRefObject<boolean>;
-  playbackRequestHeadersRef: MutableRefObject<TTSRequestHeaders | null>;
   playbackRunIdRef: MutableRefObject<number>;
   setIsPlaying: (value: boolean) => void;
   setPlaybackPhase: (phase: TtsPlaybackPhase) => void;
   setWorkerPlaybackActive: (active: boolean) => void;
-  startPlaybackForegroundSync: (runId: number, headers: TTSRequestHeaders) => void;
+  startPlaybackForegroundSync: (runId: number) => void;
   checkRecovery: () => void;
 }) {
   const {
-    audioSpeed, isPlayingRef, playbackInFlightRef, playbackRequestHeadersRef,
+    audioSpeed, isPlayingRef, playbackInFlightRef,
     playbackRunIdRef, setIsPlaying, setPlaybackPhase,
     setWorkerPlaybackActive, startPlaybackForegroundSync, checkRecovery,
   } = input;
   return useCallback((audio: HTMLAudioElement) => {
     const runId = playbackRunIdRef.current;
     setWorkerPlaybackActive(true);
-    const headers = playbackRequestHeadersRef.current;
-    if (headers) startPlaybackForegroundSync(runId, headers);
+    startPlaybackForegroundSync(runId);
     audio.playbackRate = audioSpeed;
     playbackInFlightRef.current = true;
     setPlaybackPhase('buffering');
@@ -38,7 +35,7 @@ export function usePlaybackMediaResume(input: {
       runId === playbackRunIdRef.current && isPlayingRef.current
     )).then((result) => { if (result.status === 'stale') checkRecovery(); });
   }, [
-    audioSpeed, isPlayingRef, playbackInFlightRef, playbackRequestHeadersRef,
+    audioSpeed, isPlayingRef, playbackInFlightRef,
     playbackRunIdRef, setIsPlaying, setPlaybackPhase,
     setWorkerPlaybackActive, startPlaybackForegroundSync, checkRecovery,
   ]);

--- a/src/hooks/audio/usePlaybackMediaResume.ts
+++ b/src/hooks/audio/usePlaybackMediaResume.ts
@@ -12,7 +12,6 @@ export function usePlaybackMediaResume(input: {
   playbackRequestHeadersRef: MutableRefObject<TTSRequestHeaders | null>;
   playbackRunIdRef: MutableRefObject<number>;
   setIsPlaying: (value: boolean) => void;
-  setIsProcessing: (value: boolean) => void;
   setPlaybackPhase: (phase: TtsPlaybackPhase) => void;
   setWorkerPlaybackActive: (active: boolean) => void;
   startPlaybackForegroundSync: (runId: number, headers: TTSRequestHeaders) => void;
@@ -20,7 +19,7 @@ export function usePlaybackMediaResume(input: {
 }) {
   const {
     audioSpeed, isPlayingRef, playbackInFlightRef, playbackRequestHeadersRef,
-    playbackRunIdRef, setIsPlaying, setIsProcessing, setPlaybackPhase,
+    playbackRunIdRef, setIsPlaying, setPlaybackPhase,
     setWorkerPlaybackActive, startPlaybackForegroundSync, checkRecovery,
   } = input;
   return useCallback((audio: HTMLAudioElement) => {
@@ -31,7 +30,6 @@ export function usePlaybackMediaResume(input: {
     audio.playbackRate = audioSpeed;
     playbackInFlightRef.current = true;
     setPlaybackPhase('buffering');
-    setIsProcessing(true);
     isPlayingRef.current = true;
     setIsPlaying(true);
     // Recovery also watches play() promises that never settle. Neither path
@@ -41,7 +39,7 @@ export function usePlaybackMediaResume(input: {
     )).then((result) => { if (result.status === 'stale') checkRecovery(); });
   }, [
     audioSpeed, isPlayingRef, playbackInFlightRef, playbackRequestHeadersRef,
-    playbackRunIdRef, setIsPlaying, setIsProcessing, setPlaybackPhase,
+    playbackRunIdRef, setIsPlaying, setPlaybackPhase,
     setWorkerPlaybackActive, startPlaybackForegroundSync, checkRecovery,
   ]);
 }

--- a/src/hooks/audio/usePlaybackSeek.ts
+++ b/src/hooks/audio/usePlaybackSeek.ts
@@ -18,6 +18,7 @@ type UsePlaybackSeekInput = {
   audioRef: MutableRefObject<HTMLAudioElement | null>;
   audioSpeed: number;
   isPlayingRef: MutableRefObject<boolean>;
+  onPendingSeekExpired: () => void;
   playbackActiveRef: MutableRefObject<boolean>;
   playbackRunIdRef: MutableRefObject<number>;
   playbackSeekLayout: TtsPlaybackSeekLayout | null;
@@ -42,6 +43,7 @@ export function usePlaybackSeek(input: UsePlaybackSeekInput) {
     audioRef,
     audioSpeed,
     isPlayingRef,
+    onPendingSeekExpired,
     playbackActiveRef,
     playbackRunIdRef,
     playbackSeekLayout,
@@ -108,10 +110,12 @@ export function usePlaybackSeek(input: UsePlaybackSeekInput) {
     if (!pendingSeek) return undefined;
     const delay = Math.max(0, pendingSeek.expiresAt - Date.now());
     const timeout = setTimeout(() => {
-      if (pendingSeekRef.current === pendingSeek) setPendingSeek(null);
+      if (pendingSeekRef.current !== pendingSeek) return;
+      setPendingSeek(null);
+      onPendingSeekExpired();
     }, delay);
     return () => clearTimeout(timeout);
-  }, [pendingSeek, setPendingSeek]);
+  }, [onPendingSeekExpired, pendingSeek, setPendingSeek]);
 
   useEffect(() => {
     if (!pendingSeek) return undefined;

--- a/src/hooks/audio/usePlaybackSeek.ts
+++ b/src/hooks/audio/usePlaybackSeek.ts
@@ -1,0 +1,258 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
+
+import type { TtsPlaybackSeekLayout } from '@/lib/client/api/tts';
+import { isPlaybackStartBufferReady } from '@/lib/client/tts/playback-control';
+import type { PlaybackSessionState } from '@/hooks/audio/usePlaybackProjection';
+import type { TTSSegmentLocator } from '@/types/client';
+import type { TtsPlaybackPhase } from '@/types/tts';
+
+type PendingSeek = {
+  ordinal: number;
+  runId: number;
+  expiresAt: number;
+};
+
+type UsePlaybackSeekInput = {
+  audioRef: MutableRefObject<HTMLAudioElement | null>;
+  audioSpeed: number;
+  isPlayingRef: MutableRefObject<boolean>;
+  playbackActiveRef: MutableRefObject<boolean>;
+  playbackRunIdRef: MutableRefObject<number>;
+  playbackSeekLayout: TtsPlaybackSeekLayout | null;
+  playbackSessionRef: MutableRefObject<PlaybackSessionState | null>;
+  projectPlaybackTime: (seconds: number) => void;
+  publishPlaybackTimeSec: (seconds: number, options?: { force?: boolean }) => void;
+  refreshPlaybackTimeline: (timelineUrl: string, signal?: AbortSignal) => Promise<unknown>;
+  setAudioDocumentTime: (
+    audio: HTMLAudioElement,
+    documentTimeSec: number,
+    targetOrdinal: number,
+    targetStartSec: number,
+  ) => void;
+  setPlaybackPhase: (phase: TtsPlaybackPhase) => void;
+  setSelectedOrdinal: (ordinal: number | null) => void;
+  syncPlaybackLocator?: (locator: TTSSegmentLocator | null) => void;
+  updateWorkerPlaybackCursor: (ordinal: number) => void;
+};
+
+export function usePlaybackSeek(input: UsePlaybackSeekInput) {
+  const {
+    audioRef,
+    audioSpeed,
+    isPlayingRef,
+    playbackActiveRef,
+    playbackRunIdRef,
+    playbackSeekLayout,
+    playbackSessionRef,
+    projectPlaybackTime,
+    publishPlaybackTimeSec,
+    refreshPlaybackTimeline,
+    setAudioDocumentTime,
+    setPlaybackPhase,
+    setSelectedOrdinal,
+    syncPlaybackLocator,
+    updateWorkerPlaybackCursor,
+  } = input;
+  const [pendingSeek, setPendingSeekState] = useState<PendingSeek | null>(null);
+  const pendingSeekRef = useRef<PendingSeek | null>(null);
+
+  const setPendingSeek = useCallback((next: PendingSeek | null) => {
+    pendingSeekRef.current = next;
+    setPendingSeekState(next);
+  }, []);
+
+  const cancelPendingSeek = useCallback(() => setPendingSeek(null), [setPendingSeek]);
+
+  const applyReadyMediaPosition = useCallback((
+    documentTimeSec: number,
+    ordinal: number,
+    segmentStartSec: number,
+  ) => {
+    const audio = audioRef.current;
+    if (!audio || !playbackActiveRef.current || !audio.src) return;
+    try {
+      setAudioDocumentTime(audio, documentTimeSec, ordinal, segmentStartSec);
+    } catch {
+      // Projection still updates even when a browser rejects the media seek.
+    }
+    if (isPlayingRef.current) {
+      audio.playbackRate = audioSpeed;
+      void audio.play().catch(() => undefined);
+      setPlaybackPhase('playing');
+    } else {
+      setPlaybackPhase('ready');
+    }
+  }, [
+    audioRef,
+    audioSpeed,
+    isPlayingRef,
+    playbackActiveRef,
+    setAudioDocumentTime,
+    setPlaybackPhase,
+  ]);
+
+  const startPendingSeek = useCallback((ordinal: number) => {
+    const normalizedOrdinal = Math.max(0, Math.floor(ordinal));
+    setPendingSeek({
+      ordinal: normalizedOrdinal,
+      runId: playbackRunIdRef.current,
+      expiresAt: Date.now() + 60_000,
+    });
+    setPlaybackPhase('buffering');
+    updateWorkerPlaybackCursor(normalizedOrdinal);
+  }, [playbackRunIdRef, setPendingSeek, setPlaybackPhase, updateWorkerPlaybackCursor]);
+
+  useEffect(() => {
+    if (!pendingSeek) return undefined;
+    const delay = Math.max(0, pendingSeek.expiresAt - Date.now());
+    const timeout = setTimeout(() => {
+      if (pendingSeekRef.current === pendingSeek) setPendingSeek(null);
+    }, delay);
+    return () => clearTimeout(timeout);
+  }, [pendingSeek, setPendingSeek]);
+
+  useEffect(() => {
+    if (!pendingSeek) return undefined;
+    if (pendingSeek.runId !== playbackRunIdRef.current) {
+      setPendingSeek(null);
+      return undefined;
+    }
+    const layout = playbackSeekLayout;
+    const slot = layout?.segments.find((segment) => segment.ordinal === pendingSeek.ordinal);
+    if (!layout || !slot?.generated || !isPlaybackStartBufferReady({
+      segments: layout.segments,
+      startOrdinal: pendingSeek.ordinal,
+      playbackRate: audioSpeed,
+    })) return undefined;
+
+    const session = playbackSessionRef.current;
+    if (!session) return undefined;
+    let current = true;
+    void refreshPlaybackTimeline(session.timelineUrl)
+      .catch(() => undefined)
+      .then(() => {
+        if (!current || pendingSeekRef.current !== pendingSeek
+          || pendingSeek.runId !== playbackRunIdRef.current
+          || playbackSessionRef.current !== session) return;
+        const targetSec = Math.max(0, slot.startMs / 1000);
+        setSelectedOrdinal(pendingSeek.ordinal);
+        applyReadyMediaPosition(targetSec, pendingSeek.ordinal, targetSec);
+        publishPlaybackTimeSec(targetSec, { force: true });
+        projectPlaybackTime(targetSec);
+        setPendingSeek(null);
+      });
+    return () => { current = false; };
+  }, [
+    applyReadyMediaPosition,
+    audioSpeed,
+    pendingSeek,
+    playbackRunIdRef,
+    playbackSeekLayout,
+    playbackSessionRef,
+    projectPlaybackTime,
+    publishPlaybackTimeSec,
+    refreshPlaybackTimeline,
+    setPendingSeek,
+    setSelectedOrdinal,
+  ]);
+
+  const seekPlaybackTo = useCallback((seconds: number) => {
+    const layout = playbackSeekLayout;
+    if (!layout || layout.segments.length === 0) return;
+    setPlaybackPhase('seeking');
+    const durationSec = Math.max(0, layout.durationMs / 1000);
+    const targetSec = Math.max(0, Math.min(seconds, durationSec));
+    const targetMs = targetSec * 1000;
+    const target = layout.segments.find((segment) => targetMs >= segment.startMs && targetMs < segment.endMs)
+      ?? layout.segments[layout.segments.length - 1];
+    if (!target) return;
+
+    const targetStartSec = Math.max(0, target.startMs / 1000);
+    publishPlaybackTimeSec(target.generated ? targetSec : targetStartSec, { force: true });
+    setSelectedOrdinal(target.ordinal);
+    if (target.locator && typeof target.locator === 'object') {
+      syncPlaybackLocator?.(target.locator as TTSSegmentLocator);
+    }
+
+    const audio = audioRef.current;
+    const hasReadyBuffer = target.generated && isPlaybackStartBufferReady({
+      segments: layout.segments,
+      startOrdinal: target.ordinal,
+      playbackRate: audioSpeed,
+      offsetWithinStartSegmentMs: Math.max(0, targetMs - target.startMs),
+    });
+
+    if (hasReadyBuffer) {
+      cancelPendingSeek();
+      updateWorkerPlaybackCursor(target.ordinal);
+      applyReadyMediaPosition(targetSec, target.ordinal, targetStartSec);
+      projectPlaybackTime(targetSec);
+      return;
+    }
+
+    if (isPlayingRef.current && audio) {
+      try {
+        audio.pause();
+      } catch {
+        // Ignore media pause errors while changing the stream range.
+      }
+      setPlaybackPhase('buffering');
+    }
+    if (audio && playbackActiveRef.current && audio.src) {
+      try {
+        setAudioDocumentTime(audio, targetStartSec, target.ordinal, targetStartSec);
+      } catch {
+        // The readiness update re-seeks accurately once audio is available.
+      }
+    }
+    projectPlaybackTime(targetStartSec);
+    startPendingSeek(target.ordinal);
+  }, [
+    audioRef,
+    audioSpeed,
+    applyReadyMediaPosition,
+    cancelPendingSeek,
+    isPlayingRef,
+    playbackActiveRef,
+    playbackSeekLayout,
+    projectPlaybackTime,
+    publishPlaybackTimeSec,
+    setAudioDocumentTime,
+    setPlaybackPhase,
+    setSelectedOrdinal,
+    startPendingSeek,
+    syncPlaybackLocator,
+    updateWorkerPlaybackCursor,
+  ]);
+
+  const seekPlaybackToOrdinal = useCallback((ordinal: number): boolean => {
+    const layout = playbackSeekLayout;
+    if (!layout || !Number.isFinite(ordinal)) return false;
+    const target = layout.segments.find((entry) => entry.ordinal === Math.max(0, Math.floor(ordinal)));
+    if (!target) return false;
+    seekPlaybackTo(target.startMs / 1000);
+    return true;
+  }, [playbackSeekLayout, seekPlaybackTo]);
+
+  const syncActivePlaybackToOrdinal = useCallback((ordinal: number): boolean => {
+    if (!playbackActiveRef.current || !playbackSessionRef.current) return false;
+    return seekPlaybackToOrdinal(ordinal);
+  }, [playbackActiveRef, playbackSessionRef, seekPlaybackToOrdinal]);
+
+  const getPendingSeekOrdinal = useCallback(() => pendingSeekRef.current?.ordinal ?? null, []);
+  const hasPendingSeek = useCallback(() => pendingSeekRef.current !== null, []);
+
+  useEffect(() => () => { pendingSeekRef.current = null; }, []);
+
+  return {
+    cancelPendingSeek,
+    getPendingSeekOrdinal,
+    hasPendingSeek,
+    seekPlaybackTo,
+    seekPlaybackToOrdinal,
+    startPendingSeek,
+    syncActivePlaybackToOrdinal,
+  };
+}

--- a/src/hooks/audio/useTtsDocumentNavigation.ts
+++ b/src/hooks/audio/useTtsDocumentNavigation.ts
@@ -54,7 +54,7 @@ type UseTtsDocumentNavigationInput = {
   playbackSyncNavigationRef: MutableRefObject<boolean>;
   resumeAfterLocationChangeRef: MutableRefObject<boolean>;
   abortAudio: () => void;
-  cancelSeekResync: () => void;
+  cancelPendingSeek: () => void;
   invalidatePlaybackRun: () => void;
   pauseActivePlayback: () => void;
   seekPlaybackToOrdinal: (ordinal: number) => boolean;
@@ -84,7 +84,7 @@ export function useTtsDocumentNavigation(input: UseTtsDocumentNavigationInput) {
     playbackSyncNavigationRef,
     resumeAfterLocationChangeRef,
     abortAudio,
-    cancelSeekResync,
+    cancelPendingSeek,
     invalidatePlaybackRun,
     pauseActivePlayback,
     seekPlaybackToOrdinal,
@@ -104,11 +104,11 @@ export function useTtsDocumentNavigation(input: UseTtsDocumentNavigationInput) {
   const pause = useCallback(() => {
     resumeAfterLocationChangeRef.current = false;
     pauseEpochRef.current += 1;
-    cancelSeekResync();
+    cancelPendingSeek();
     pauseActivePlayback();
     setIsPlaying(false);
   }, [
-    cancelSeekResync,
+    cancelPendingSeek,
     pauseActivePlayback,
     pauseEpochRef,
     resumeAfterLocationChangeRef,

--- a/src/hooks/audio/useTtsPlayback.ts
+++ b/src/hooks/audio/useTtsPlayback.ts
@@ -141,6 +141,29 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     refreshPlaybackTimeline,
     setPlaybackSeekLayout,
   });
+  const onPendingSeekExpired = useCallback(() => {
+    if (!isPlayingRef.current) {
+      setPlaybackPhase('ready');
+      return;
+    }
+    isPlayingRef.current = false;
+    setWorkerPlaybackActive(false);
+    stopPlaybackProjectionLoop();
+    stopPlaybackForegroundSync();
+    playbackInFlightRef.current = false;
+    setIsPlaying(false);
+    setPlaybackPhase('failed');
+    toast.error('Audio was not ready after waiting. Try Play again.', {
+      id: 'tts-playback-error',
+      duration: 7000,
+    });
+  }, [
+    isPlayingRef,
+    setIsPlaying,
+    setWorkerPlaybackActive,
+    stopPlaybackForegroundSync,
+    stopPlaybackProjectionLoop,
+  ]);
   const {
     cancelPendingSeek,
     getPendingSeekOrdinal,
@@ -153,6 +176,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     audioRef: unlockedAudioRef,
     audioSpeed,
     isPlayingRef,
+    onPendingSeekExpired,
     playbackActiveRef,
     playbackRunIdRef,
     playbackSeekLayout,
@@ -522,7 +546,8 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   useEffect(() => () => {
     stopPlaybackRecovery();
     abortPlaybackRequest();
-  }, [abortPlaybackRequest, stopPlaybackRecovery]);
+    stopPlaybackForegroundSync();
+  }, [abortPlaybackRequest, stopPlaybackForegroundSync, stopPlaybackRecovery]);
 
   useEffect(() => {
     const onVisibilityChange = () => {

--- a/src/hooks/audio/useTtsPlayback.ts
+++ b/src/hooks/audio/useTtsPlayback.ts
@@ -23,6 +23,7 @@ import {
   resumePlaybackMedia,
   waitForPlaybackStartBuffer,
 } from '@/lib/client/tts/playback-control';
+import { usePlaybackAudioElement } from '@/hooks/audio/usePlaybackAudioElement';
 import { usePlaybackMediaResume } from '@/hooks/audio/usePlaybackMediaResume';
 import { createPlaybackRecovery, createTtsMediaRecovery } from '@/lib/client/tts/playback-recovery';
 import { installPlaybackMediaEvents } from '@/lib/client/tts/playback-media-events';
@@ -68,10 +69,6 @@ type UseTtsPlaybackInput = {
   controller: PlaybackController;
 };
 
-// Tiny silent WAV used to unlock HTML5 audio on iOS/Safari.
-const SILENT_WAV_DATA_URI =
-  'data:audio/wav;base64,UklGRkQDAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YSADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==';
-
 export function useTtsPlayback(input: UseTtsPlaybackInput) {
   const {
     audioContext,
@@ -93,8 +90,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     onAdvance,
     controller,
   } = input;
-  const unlockedAudioRef = useRef<HTMLAudioElement | null>(null);
-  const audioUnlockAttemptRef = useRef(0);
   const playbackInFlightRef = useRef(false);
   const playbackSessionRef = useRef<PlaybackSessionState | null>(null);
   const playbackActiveRef = useRef(false);
@@ -107,6 +102,12 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   useEffect(() => { latestSeekLayoutRef.current = playbackSeekLayout; }, [playbackSeekLayout]);
   const checkRecovery = useCallback(() => { playbackRecoveryRef.current?.check(); }, []);
   const [playbackPhase, setPlaybackPhase] = useState<TtsPlaybackPhase>('idle');
+  const {
+    audioRef: unlockedAudioRef,
+    clearAudioSource,
+    ensureAudio,
+    unlockAudioOnUserGesture,
+  } = usePlaybackAudioElement({ audioContext, audioSpeed });
 
   const {
     playbackCursorOrdinalRef,
@@ -172,54 +173,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     abortPlaybackRequest();
   }, [abortPlaybackRequest, playbackRunIdRef, stopPlaybackRecovery]);
 
-  const unlockPlaybackOnUserGesture = useCallback(() => {
-    audioUnlockAttemptRef.current += 1;
-    const attempt = audioUnlockAttemptRef.current;
-
-    try {
-      void audioContext?.resume();
-    } catch {
-      // ignore
-    }
-
-    try {
-      let el = unlockedAudioRef.current;
-      if (!el) {
-        el = new Audio();
-        try {
-          el.setAttribute('playsinline', 'true');
-        } catch {
-          // ignore
-        }
-        el.preload = 'auto';
-        unlockedAudioRef.current = el;
-      }
-      if (playbackActiveRef.current && el.src && el.src !== SILENT_WAV_DATA_URI) {
-        return;
-      }
-      el.src = SILENT_WAV_DATA_URI;
-      el.volume = 0;
-
-      const p = el.play();
-      if (p && typeof (p as Promise<void>).then === 'function') {
-        void (p as Promise<void>)
-          .then(() => {
-            if (audioUnlockAttemptRef.current !== attempt) return;
-            try {
-              el!.pause();
-              el!.currentTime = 0;
-              el!.volume = 1;
-            } catch {
-              // ignore
-            }
-          })
-          .catch(() => undefined);
-      }
-    } catch {
-      // ignore
-    }
-  }, [audioContext]);
-
   const resetPlaybackSession = useCallback(() => {
     stopPlaybackRecovery();
     stopPlaybackForegroundSync();
@@ -235,19 +188,11 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     invalidatePlaybackRun();
     cancelSeekResync();
     resetPlaybackSession();
-    const audio = unlockedAudioRef.current;
-    if (audio) {
-      try {
-        audio.pause();
-        audio.removeAttribute('src');
-        audio.load();
-      } catch {
-        // ignore teardown errors
-      }
-    }
+    clearAudioSource();
     setCurrentWordIndex(null);
   }, [
     cancelSeekResync,
+    clearAudioSource,
     invalidatePlaybackRun,
     resetPlaybackSession,
     setWorkerPlaybackActive,
@@ -468,15 +413,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
 
     resetPlaybackSession();
     setPlaybackPhase('planning');
-    if (unlockedAudioRef.current) {
-      try {
-        unlockedAudioRef.current.pause();
-        unlockedAudioRef.current.removeAttribute('src');
-        unlockedAudioRef.current.load();
-      } catch {
-        // ignore stale audio teardown
-      }
-    }
+    clearAudioSource();
 
     try {
       const plan = controller.getPlaybackPlan();
@@ -557,13 +494,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
         return Math.max(0, slot.startMs / 1000);
       })();
 
-      let audio = unlockedAudioRef.current;
-      if (!audio) {
-        audio = new Audio();
-        audio.preload = 'auto';
-        audio.setAttribute('playsinline', 'true');
-        unlockedAudioRef.current = audio;
-      }
+      const audio = ensureAudio();
       audio.defaultPlaybackRate = audioSpeed;
       audio.playbackRate = audioSpeed;
       audio.volume = 1;
@@ -647,9 +578,11 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     }
   }, [
     audioSpeed,
+    clearAudioSource,
     controller,
     checkRecovery,
     documentTimeForAudio,
+    ensureAudio,
     isPlayingRef,
     onAdvance,
     pauseActivePlayback,
@@ -693,7 +626,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     }
 
     if (pendingResyncRef.current) {
-      unlockPlaybackOnUserGesture();
+      unlockAudioOnUserGesture(playbackActiveRef.current);
       setWorkerPlaybackActive(true);
       setPlaybackPhase('buffering');
       isPlayingRef.current = true;
@@ -702,7 +635,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       return;
     }
 
-    unlockPlaybackOnUserGesture();
+    unlockAudioOnUserGesture(playbackActiveRef.current);
 
     const audio = unlockedAudioRef.current;
     if (audio && playbackActiveRef.current && audio.src) {
@@ -722,7 +655,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     setPlaybackPhase,
     setWorkerPlaybackActive,
     startSeekResync,
-    unlockPlaybackOnUserGesture,
+    unlockAudioOnUserGesture,
   ]);
 
   useEffect(() => {
@@ -761,7 +694,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   }, [documentTimeForAudio, projectPlaybackTime, refreshPlaybackTimeline]);
 
   return {
-    unlockedAudioRef,
     playbackActiveRef,
     playbackPhase,
     playbackTimeSec,

--- a/src/hooks/audio/useTtsPlayback.ts
+++ b/src/hooks/audio/useTtsPlayback.ts
@@ -10,7 +10,6 @@ import {
 import {
   createTtsPlaybackSession,
   getTtsPlaybackSeekLayout,
-  postTtsPlaybackCursor,
   type TtsPlaybackPlanPayload,
   type TtsPlaybackSeekLayout,
   type TtsPlaybackSessionPayload,
@@ -19,12 +18,12 @@ import type { TTSRequestHeaders } from '@/types/client';
 import type { TtsPlaybackPlan } from '@/lib/shared/playback-plan';
 import {
   isPlaybackAbortError,
-  isPlaybackStartBufferReady,
   resumePlaybackMedia,
   waitForPlaybackStartBuffer,
 } from '@/lib/client/tts/playback-control';
 import { usePlaybackAudioElement } from '@/hooks/audio/usePlaybackAudioElement';
 import { usePlaybackMediaResume } from '@/hooks/audio/usePlaybackMediaResume';
+import { usePlaybackSeek } from '@/hooks/audio/usePlaybackSeek';
 import { createPlaybackRecovery, createTtsMediaRecovery } from '@/lib/client/tts/playback-recovery';
 import { installPlaybackMediaEvents } from '@/lib/client/tts/playback-media-events';
 import { usePlaybackForegroundSync } from '@/hooks/audio/usePlaybackForegroundSync';
@@ -93,8 +92,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   const playbackInFlightRef = useRef(false);
   const playbackSessionRef = useRef<PlaybackSessionState | null>(null);
   const playbackActiveRef = useRef(false);
-  const pendingResyncRef = useRef<{ ordinal: number } | null>(null);
-  const resyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const playbackRequestHeadersRef = useRef<TTSRequestHeaders | null>(null);
   const playbackRequestAbortRef = useRef<AbortController | null>(null);
   const playbackRecoveryRef = useRef<ReturnType<typeof createPlaybackRecovery> | null>(null);
@@ -135,6 +132,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     setWorkerPlaybackActive,
     startPlaybackForegroundSync,
     stopPlaybackForegroundSync,
+    updateWorkerPlaybackCursor,
   } = usePlaybackForegroundSync({
     playbackCursorOrdinalRef,
     playbackRequestHeadersRef,
@@ -143,18 +141,31 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     refreshPlaybackTimeline,
     setPlaybackSeekLayout,
   });
-
-  const stopSeekResync = useCallback(() => {
-    if (resyncTimerRef.current) {
-      clearTimeout(resyncTimerRef.current);
-      resyncTimerRef.current = null;
-    }
-  }, []);
-
-  const cancelSeekResync = useCallback(() => {
-    stopSeekResync();
-    pendingResyncRef.current = null;
-  }, [stopSeekResync]);
+  const {
+    cancelPendingSeek,
+    getPendingSeekOrdinal,
+    hasPendingSeek,
+    seekPlaybackTo,
+    seekPlaybackToOrdinal,
+    startPendingSeek,
+    syncActivePlaybackToOrdinal,
+  } = usePlaybackSeek({
+    audioRef: unlockedAudioRef,
+    audioSpeed,
+    isPlayingRef,
+    playbackActiveRef,
+    playbackRunIdRef,
+    playbackSeekLayout,
+    playbackSessionRef,
+    projectPlaybackTime,
+    publishPlaybackTimeSec,
+    refreshPlaybackTimeline,
+    setAudioDocumentTime,
+    setPlaybackPhase,
+    setSelectedOrdinal,
+    syncPlaybackLocator,
+    updateWorkerPlaybackCursor,
+  });
 
   const stopPlaybackRecovery = useCallback(() => {
     playbackRecoveryRef.current?.stop();
@@ -186,12 +197,12 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   const abortAudio = useCallback(() => {
     setWorkerPlaybackActive(false);
     invalidatePlaybackRun();
-    cancelSeekResync();
+    cancelPendingSeek();
     resetPlaybackSession();
     clearAudioSource();
     setCurrentWordIndex(null);
   }, [
-    cancelSeekResync,
+    cancelPendingSeek,
     clearAudioSource,
     invalidatePlaybackRun,
     resetPlaybackSession,
@@ -225,176 +236,8 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     setWorkerPlaybackActive,
     stopPlaybackForegroundSync,
     stopPlaybackProjectionLoop,
+    unlockedAudioRef,
   ]);
-
-  const startSeekResync = useCallback((ordinal: number) => {
-    pendingResyncRef.current = { ordinal };
-    setPlaybackPhase('buffering');
-    const runId = playbackRunIdRef.current;
-    const deadline = Date.now() + 60_000;
-    const tick = async () => {
-      const pending = pendingResyncRef.current;
-      const session = playbackSessionRef.current;
-      if (!pending || pending.ordinal !== ordinal || runId !== playbackRunIdRef.current || !session?.seekLayoutUrl) {
-        return;
-      }
-      if (Date.now() > deadline) {
-        pendingResyncRef.current = null;
-        return;
-      }
-      const headers = playbackRequestHeadersRef.current;
-      if (headers) void postTtsPlaybackCursor(session.sessionId, ordinal, headers, { sessionInstanceId: session.sessionInstanceId });
-
-      const layout = await getTtsPlaybackSeekLayout(session.seekLayoutUrl).catch(() => null);
-      if (runId !== playbackRunIdRef.current || pendingResyncRef.current?.ordinal !== ordinal) return;
-      const slot = layout?.segments.find((segment) => segment.ordinal === ordinal) ?? null;
-
-      if (slot?.generated && layout && isPlaybackStartBufferReady({
-        segments: layout.segments,
-        startOrdinal: ordinal,
-        playbackRate: audioSpeed,
-      })) {
-        if (layout) setPlaybackSeekLayout(layout);
-        await refreshPlaybackTimeline(session.timelineUrl).catch(() => undefined);
-        if (runId !== playbackRunIdRef.current || pendingResyncRef.current?.ordinal !== ordinal) return;
-        const targetSec = Math.max(0, slot.startMs / 1000);
-        setSelectedOrdinal(ordinal);
-        const audio = unlockedAudioRef.current;
-        if (audio && playbackActiveRef.current && audio.src) {
-          try {
-            setAudioDocumentTime(audio, targetSec, ordinal, targetSec);
-          } catch {
-            // Best-effort; projection below still updates the UI.
-          }
-          if (isPlayingRef.current) {
-            audio.playbackRate = audioSpeed;
-            void audio.play().catch(() => undefined);
-            setPlaybackPhase('playing');
-          } else {
-            setPlaybackPhase('ready');
-          }
-        }
-        publishPlaybackTimeSec(targetSec, { force: true });
-        projectPlaybackTime(targetSec);
-        pendingResyncRef.current = null;
-        return;
-      }
-
-      resyncTimerRef.current = setTimeout(() => { void tick(); }, 600);
-    };
-    stopSeekResync();
-    void tick();
-  }, [
-    audioSpeed,
-    isPlayingRef,
-    playbackRunIdRef,
-    projectPlaybackTime,
-    publishPlaybackTimeSec,
-    refreshPlaybackTimeline,
-    setPlaybackPhase,
-    setPlaybackSeekLayout,
-    setSelectedOrdinal,
-    setAudioDocumentTime,
-    stopSeekResync,
-  ]);
-
-  const seekPlaybackTo = useCallback((seconds: number) => {
-    const layout = playbackSeekLayout;
-    if (!layout || layout.segments.length === 0) return;
-    setPlaybackPhase('seeking');
-    const durationSec = Math.max(0, layout.durationMs / 1000);
-    const targetSec = Math.max(0, Math.min(seconds, durationSec));
-    const targetMs = targetSec * 1000;
-    const target = layout.segments.find((segment) => targetMs >= segment.startMs && targetMs < segment.endMs)
-      ?? layout.segments[layout.segments.length - 1];
-    if (!target) return;
-
-    const targetStartSec = Math.max(0, target.startMs / 1000);
-    publishPlaybackTimeSec(target.generated ? targetSec : targetStartSec, { force: true });
-    setSelectedOrdinal(target.ordinal);
-    if (target.locator && typeof target.locator === 'object') {
-      syncPlaybackLocator?.(target.locator as import('@/types/client').TTSSegmentLocator);
-    }
-
-    const session = playbackSessionRef.current;
-    const headers = playbackRequestHeadersRef.current;
-    if (session && headers) {
-      void postTtsPlaybackCursor(session.sessionId, target.ordinal, headers, { sessionInstanceId: session.sessionInstanceId });
-    }
-
-    const audio = unlockedAudioRef.current;
-
-    const hasReadyBuffer = target.generated && isPlaybackStartBufferReady({
-      segments: layout.segments,
-      startOrdinal: target.ordinal,
-      playbackRate: audioSpeed,
-      offsetWithinStartSegmentMs: Math.max(0, targetMs - target.startMs),
-    });
-
-    if (hasReadyBuffer) {
-      cancelSeekResync();
-      if (audio && playbackActiveRef.current && audio.src) {
-        try {
-          setAudioDocumentTime(audio, targetSec, target.ordinal, targetStartSec);
-        } catch {
-          // Best-effort; the projection still updates immediately below.
-        }
-        if (isPlayingRef.current) {
-          audio.playbackRate = audioSpeed;
-          void audio.play().catch(() => undefined);
-          setPlaybackPhase('playing');
-        } else {
-          setPlaybackPhase('ready');
-        }
-      }
-      projectPlaybackTime(targetSec);
-      return;
-    }
-
-    if (isPlayingRef.current && audio) {
-      try {
-        audio.pause();
-      } catch {
-        // ignore
-      }
-      setPlaybackPhase('buffering');
-    }
-    if (audio && playbackActiveRef.current && audio.src) {
-      try {
-        setAudioDocumentTime(audio, targetStartSec, target.ordinal, targetStartSec);
-      } catch {
-        // Best-effort; the resync re-seeks accurately when the audio is ready.
-      }
-    }
-    projectPlaybackTime(targetStartSec);
-    startSeekResync(target.ordinal);
-  }, [
-    audioSpeed,
-    cancelSeekResync,
-    isPlayingRef,
-    playbackSeekLayout,
-    projectPlaybackTime,
-    publishPlaybackTimeSec,
-    setPlaybackPhase,
-    setSelectedOrdinal,
-    setAudioDocumentTime,
-    startSeekResync,
-    syncPlaybackLocator,
-  ]);
-
-  const seekPlaybackToOrdinal = useCallback((ordinal: number): boolean => {
-    const layout = playbackSeekLayout;
-    if (!layout || !Number.isFinite(ordinal)) return false;
-    const target = layout.segments.find((entry) => entry.ordinal === Math.max(0, Math.floor(ordinal)));
-    if (!target) return false;
-    seekPlaybackTo(target.startMs / 1000);
-    return true;
-  }, [playbackSeekLayout, seekPlaybackTo]);
-
-  const syncActivePlaybackToOrdinal = useCallback((ordinal: number): boolean => {
-    if (!playbackActiveRef.current || !playbackSessionRef.current) return false;
-    return seekPlaybackToOrdinal(ordinal);
-  }, [seekPlaybackToOrdinal]);
 
   const playWorkerPlaybackStream = useCallback(async () => {
     const runId = playbackRunIdRef.current;
@@ -467,7 +310,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       playbackCursorOrdinalRef.current = requestedStartOrdinal;
       await setWorkerPlaybackActive(true, true);
       if (runId !== playbackRunIdRef.current || !isPlayingRef.current) return;
-      startPlaybackForegroundSync(runId, headers);
+      startPlaybackForegroundSync(runId);
 
       const initialSeekLayout = await waitForPlaybackStartBuffer({
         loadLayout: () => getTtsPlaybackSeekLayout(session.seekLayoutUrl).catch(() => null),
@@ -538,7 +381,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
         sessionUrl: session.audioUrl,
         isCurrent: () => runId === playbackRunIdRef.current && isPlayingRef.current
           && playbackActiveRef.current && playbackSessionRef.current === activeSession
-          && !pendingResyncRef.current,
+          && !hasPendingSeek(),
         getDocumentTime: () => documentTimeForAudio(audio),
         getOrdinal: () => playbackCursorOrdinalRef.current,
         getLayout: () => latestSeekLayoutRef.current,
@@ -583,6 +426,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     checkRecovery,
     documentTimeForAudio,
     ensureAudio,
+    hasPendingSeek,
     isPlayingRef,
     onAdvance,
     pauseActivePlayback,
@@ -608,7 +452,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     audioSpeed,
     isPlayingRef,
     playbackInFlightRef,
-    playbackRequestHeadersRef,
     playbackRunIdRef,
     checkRecovery,
     setIsPlaying,
@@ -619,19 +462,21 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
 
   const togglePlay = useCallback(() => {
     if (isPlaying) {
-      cancelSeekResync();
+      cancelPendingSeek();
       pauseActivePlayback();
       setIsPlaying(false);
       return;
     }
 
-    if (pendingResyncRef.current) {
+    const pendingSeekOrdinal = getPendingSeekOrdinal();
+    if (pendingSeekOrdinal !== null) {
       unlockAudioOnUserGesture(playbackActiveRef.current);
       setWorkerPlaybackActive(true);
       setPlaybackPhase('buffering');
       isPlayingRef.current = true;
       setIsPlaying(true);
-      startSeekResync(pendingResyncRef.current.ordinal);
+      startPlaybackForegroundSync(playbackRunIdRef.current);
+      startPendingSeek(pendingSeekOrdinal);
       return;
     }
 
@@ -646,16 +491,20 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     isPlayingRef.current = true;
     setIsPlaying(true);
   }, [
-    cancelSeekResync,
+    cancelPendingSeek,
+    getPendingSeekOrdinal,
     isPlaying,
     isPlayingRef,
     pauseActivePlayback,
+    playbackRunIdRef,
     resumeActivePlayback,
     setIsPlaying,
     setPlaybackPhase,
     setWorkerPlaybackActive,
-    startSeekResync,
+    startPendingSeek,
+    startPlaybackForegroundSync,
     unlockAudioOnUserGesture,
+    unlockedAudioRef,
   ]);
 
   useEffect(() => {
@@ -691,15 +540,14 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
     return () => document.removeEventListener('visibilitychange', onVisibilityChange);
-  }, [documentTimeForAudio, projectPlaybackTime, refreshPlaybackTimeline]);
+  }, [documentTimeForAudio, projectPlaybackTime, refreshPlaybackTimeline, unlockedAudioRef]);
 
   return {
     playbackActiveRef,
     playbackPhase,
     playbackTimeSec,
-    publishPlaybackTimeSec,
     abortAudio,
-    cancelSeekResync,
+    cancelPendingSeek,
     invalidatePlaybackRun,
     pauseActivePlayback,
     seekPlaybackTo,

--- a/src/hooks/audio/useTtsPlayback.ts
+++ b/src/hooks/audio/useTtsPlayback.ts
@@ -58,7 +58,6 @@ type UseTtsPlaybackInput = {
   selectedOrdinalRef: MutableRefObject<number | null>;
   playbackRunIdRef: MutableRefObject<number>;
   setIsPlaying: (isPlaying: boolean) => void;
-  setIsProcessing: (isProcessing: boolean) => void;
   setCurrDocPage: (location: TTSLocation) => void;
   syncPlaybackLocator?: (locator: import('@/types/client').TTSSegmentLocator | null) => void;
   setSelectedOrdinal: (ordinal: number | null) => void;
@@ -85,7 +84,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     selectedOrdinalRef,
     playbackRunIdRef,
     setIsPlaying,
-    setIsProcessing,
     setCurrDocPage,
     syncPlaybackLocator,
     setSelectedOrdinal,
@@ -108,13 +106,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   const latestSeekLayoutRef = useRef(playbackSeekLayout);
   useEffect(() => { latestSeekLayoutRef.current = playbackSeekLayout; }, [playbackSeekLayout]);
   const checkRecovery = useCallback(() => { playbackRecoveryRef.current?.check(); }, []);
-  const playbackPhaseRef = useRef<TtsPlaybackPhase>('idle');
-  const [playbackPhase, setPlaybackPhaseState] = useState<TtsPlaybackPhase>('idle');
-
-  const setPlaybackPhase = useCallback((phase: TtsPlaybackPhase) => {
-    playbackPhaseRef.current = phase;
-    setPlaybackPhaseState(phase);
-  }, []);
+  const [playbackPhase, setPlaybackPhase] = useState<TtsPlaybackPhase>('idle');
 
   const {
     playbackCursorOrdinalRef,
@@ -163,14 +155,22 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     pendingResyncRef.current = null;
   }, [stopSeekResync]);
 
-  const invalidatePlaybackRun = useCallback(() => {
-    playbackRunIdRef.current += 1;
+  const stopPlaybackRecovery = useCallback(() => {
     playbackRecoveryRef.current?.stop();
     playbackRecoveryRef.current = null;
-    playbackInFlightRef.current = false;
+  }, []);
+
+  const abortPlaybackRequest = useCallback(() => {
     playbackRequestAbortRef.current?.abort();
     playbackRequestAbortRef.current = null;
-  }, [playbackRunIdRef]);
+  }, []);
+
+  const invalidatePlaybackRun = useCallback(() => {
+    playbackRunIdRef.current += 1;
+    stopPlaybackRecovery();
+    playbackInFlightRef.current = false;
+    abortPlaybackRequest();
+  }, [abortPlaybackRequest, playbackRunIdRef, stopPlaybackRecovery]);
 
   const unlockPlaybackOnUserGesture = useCallback(() => {
     audioUnlockAttemptRef.current += 1;
@@ -220,24 +220,21 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     }
   }, [audioContext]);
 
-  const resetPlaybackRefs = useCallback(() => {
-    playbackRecoveryRef.current?.stop();
-    playbackRecoveryRef.current = null;
+  const resetPlaybackSession = useCallback(() => {
+    stopPlaybackRecovery();
     stopPlaybackForegroundSync();
     playbackActiveRef.current = false;
     playbackSessionRef.current = null;
     playbackRequestHeadersRef.current = null;
     resetPlaybackProjection();
     setPlaybackPhase('idle');
-  }, [resetPlaybackProjection, setPlaybackPhase, stopPlaybackForegroundSync]);
+  }, [resetPlaybackProjection, stopPlaybackForegroundSync, stopPlaybackRecovery]);
 
   const abortAudio = useCallback(() => {
     setWorkerPlaybackActive(false);
     invalidatePlaybackRun();
     cancelSeekResync();
-    stopPlaybackProjectionLoop();
-    resetPlaybackRefs();
-    publishPlaybackTimeSec(0, { force: true });
+    resetPlaybackSession();
     const audio = unlockedAudioRef.current;
     if (audio) {
       try {
@@ -252,11 +249,9 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   }, [
     cancelSeekResync,
     invalidatePlaybackRun,
-    publishPlaybackTimeSec,
-    resetPlaybackRefs,
+    resetPlaybackSession,
     setWorkerPlaybackActive,
     setCurrentWordIndex,
-    stopPlaybackProjectionLoop,
   ]);
 
   const pauseActivePlayback = useCallback(() => {
@@ -274,7 +269,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     stopPlaybackProjectionLoop();
     stopPlaybackForegroundSync();
     playbackInFlightRef.current = false;
-    setIsProcessing(false);
     setPlaybackPhase('ready');
     if ('mediaSession' in navigator) {
       navigator.mediaSession.playbackState = 'paused';
@@ -282,7 +276,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   }, [
     invalidatePlaybackRun,
     isPlayingRef,
-    setIsProcessing,
     setPlaybackPhase,
     setWorkerPlaybackActive,
     stopPlaybackForegroundSync,
@@ -302,7 +295,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       }
       if (Date.now() > deadline) {
         pendingResyncRef.current = null;
-        setIsProcessing(false);
         return;
       }
       const headers = playbackRequestHeadersRef.current;
@@ -340,7 +332,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
         publishPlaybackTimeSec(targetSec, { force: true });
         projectPlaybackTime(targetSec);
         pendingResyncRef.current = null;
-        setIsProcessing(false);
         return;
       }
 
@@ -355,7 +346,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     projectPlaybackTime,
     publishPlaybackTimeSec,
     refreshPlaybackTimeline,
-    setIsProcessing,
     setPlaybackPhase,
     setPlaybackSeekLayout,
     setSelectedOrdinal,
@@ -398,7 +388,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
 
     if (hasReadyBuffer) {
       cancelSeekResync();
-      setIsProcessing(false);
       if (audio && playbackActiveRef.current && audio.src) {
         try {
           setAudioDocumentTime(audio, targetSec, target.ordinal, targetStartSec);
@@ -423,7 +412,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       } catch {
         // ignore
       }
-      setIsProcessing(true);
       setPlaybackPhase('buffering');
     }
     if (audio && playbackActiveRef.current && audio.src) {
@@ -442,7 +430,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     playbackSeekLayout,
     projectPlaybackTime,
     publishPlaybackTimeSec,
-    setIsProcessing,
     setPlaybackPhase,
     setSelectedOrdinal,
     setAudioDocumentTime,
@@ -471,18 +458,15 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     // before stale work can put the controls back into a processing state.
     if (!isPlayingRef.current) {
       playbackInFlightRef.current = false;
-      setIsProcessing(false);
       return;
     }
     const request = controller.buildPlaybackPlanRequest();
     if (!request) {
       playbackInFlightRef.current = false;
-      setIsProcessing(false);
       return;
     }
 
-    resetPlaybackRefs();
-    setIsProcessing(true);
+    resetPlaybackSession();
     setPlaybackPhase('planning');
     if (unlockedAudioRef.current) {
       try {
@@ -583,7 +567,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       audio.defaultPlaybackRate = audioSpeed;
       audio.playbackRate = audioSpeed;
       audio.volume = 1;
-      const recover = () => { setPlaybackPhase('buffering'); setIsProcessing(true); checkRecovery(); };
+      const recover = () => { setPlaybackPhase('buffering'); checkRecovery(); };
       installPlaybackMediaEvents({ audio, audioSpeed,
         isCurrent: () => runId === playbackRunIdRef.current,
         isPlaying: () => isPlayingRef.current,
@@ -599,8 +583,8 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
         onBuffering: recover, onRecover: recover,
         onEnded: () => {
           setWorkerPlaybackActive(false); stopPlaybackProjectionLoop();
-          playbackInFlightRef.current = false; setIsProcessing(false); resetPlaybackRefs();
-          setPlaybackPhase('ended'); playbackRequestHeadersRef.current = null;
+          playbackInFlightRef.current = false; resetPlaybackSession();
+          setPlaybackPhase('ended');
           if (isPlayingRef.current) void onAdvance();
         },
         onTime: () => {
@@ -609,7 +593,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
           projectPlaybackTime(documentTimeSec);
         },
         onPlaying: () => {
-          setPlaybackPhase('playing'); startPlaybackProjectionLoop(audio, runId); setIsProcessing(false);
+          setPlaybackPhase('playing'); startPlaybackProjectionLoop(audio, runId);
         },
       });
 
@@ -630,7 +614,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
         setStreamBase: (seconds) => { playbackStreamBaseSecRef.current = seconds; },
         onBuffering: () => {
           setPlaybackPhase('buffering');
-          setIsProcessing(true);
         },
         onExhausted: () => {
           pauseActivePlayback();
@@ -654,8 +637,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       setWorkerPlaybackActive(false);
       stopPlaybackProjectionLoop();
       playbackInFlightRef.current = false;
-      setIsProcessing(false);
-      resetPlaybackRefs();
+      resetPlaybackSession();
       setIsPlaying(false);
       setPlaybackPhase('failed');
       toast.error('TTS playback failed. Paused playback.', {
@@ -678,9 +660,8 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     projectPlaybackTime,
     publishPlaybackTimeSec,
     refreshPlaybackTimeline,
-    resetPlaybackRefs,
+    resetPlaybackSession,
     setIsPlaying,
-    setIsProcessing,
     setPlaybackPhase,
     setPlaybackSeekLayout,
     setSelectedOrdinal,
@@ -698,7 +679,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     playbackRunIdRef,
     checkRecovery,
     setIsPlaying,
-    setIsProcessing,
     setPlaybackPhase,
     setWorkerPlaybackActive,
     startPlaybackForegroundSync,
@@ -707,7 +687,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   const togglePlay = useCallback(() => {
     if (isPlaying) {
       cancelSeekResync();
-      setIsProcessing(false);
       pauseActivePlayback();
       setIsPlaying(false);
       return;
@@ -716,7 +695,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     if (pendingResyncRef.current) {
       unlockPlaybackOnUserGesture();
       setWorkerPlaybackActive(true);
-      setIsProcessing(true);
       setPlaybackPhase('buffering');
       isPlayingRef.current = true;
       setIsPlaying(true);
@@ -741,7 +719,6 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     pauseActivePlayback,
     resumeActivePlayback,
     setIsPlaying,
-    setIsProcessing,
     setPlaybackPhase,
     setWorkerPlaybackActive,
     startSeekResync,
@@ -760,7 +737,10 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     void playWorkerPlaybackStream();
   }, [canStartPlayback, isPlaying, playWorkerPlaybackStream]);
 
-  useEffect(() => () => { playbackRecoveryRef.current?.stop(); }, []);
+  useEffect(() => () => {
+    stopPlaybackRecovery();
+    abortPlaybackRequest();
+  }, [abortPlaybackRequest, stopPlaybackRecovery]);
 
   useEffect(() => {
     const onVisibilityChange = () => {

--- a/src/lib/client/tts/playback-control.ts
+++ b/src/lib/client/tts/playback-control.ts
@@ -146,6 +146,18 @@ export type PlaybackControlPresentation = {
   statusText: 'Preparing audio…' | 'Loading audio…' | null;
 };
 
+export function isPlaybackPhaseProcessing(
+  isPlaying: boolean,
+  phase: TtsPlaybackPhase,
+): boolean {
+  return isPlaying && (
+    phase === 'planning'
+    || phase === 'ready'
+    || phase === 'seeking'
+    || phase === 'buffering'
+  );
+}
+
 export function resolvePlaybackControlPresentation(
   isPlaying: boolean,
   phase: TtsPlaybackPhase,

--- a/tests/unit/playback-control.vitest.spec.ts
+++ b/tests/unit/playback-control.vitest.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import {
   isPlaybackAbortError,
+  isPlaybackPhaseProcessing,
   isPlaybackStartBufferReady,
   measurePlaybackStartBuffer,
   resumePlaybackMedia,
@@ -38,6 +39,16 @@ describe('playback media resume', () => {
 });
 
 describe('playback control presentation', () => {
+  test('derives processing from playback intent and lifecycle phase', () => {
+    expect(isPlaybackPhaseProcessing(true, 'planning')).toBe(true);
+    expect(isPlaybackPhaseProcessing(true, 'ready')).toBe(true);
+    expect(isPlaybackPhaseProcessing(true, 'buffering')).toBe(true);
+    expect(isPlaybackPhaseProcessing(true, 'seeking')).toBe(true);
+    expect(isPlaybackPhaseProcessing(true, 'playing')).toBe(false);
+    expect(isPlaybackPhaseProcessing(false, 'ready')).toBe(false);
+    expect(isPlaybackPhaseProcessing(true, 'failed')).toBe(false);
+  });
+
   test('does not claim playback is audible while planning or buffering', () => {
     expect(resolvePlaybackControlPresentation(true, 'planning')).toEqual({
       isPending: true,

--- a/tests/unit/server-state-architecture.vitest.spec.ts
+++ b/tests/unit/server-state-architecture.vitest.spec.ts
@@ -582,6 +582,7 @@ describe('server-state architecture', () => {
     expect(playbackSeek).not.toContain('postTtsPlaybackCursor');
     expect(playbackSeek).not.toContain('getTtsPlaybackSeekLayout');
     expect(playbackSeek).not.toContain('setTimeout(() => { void tick(); }, 600)');
+    expect(playbackSeek).toContain('onPendingSeekExpired();');
     // Heartbeats and explicit seeks share the playhead cursor writer. It uses
     // the projected ordinal when no seek target is supplied and never derives
     // the cursor from UI indexes. `null` means no faithful playhead yet.

--- a/tests/unit/server-state-architecture.vitest.spec.ts
+++ b/tests/unit/server-state-architecture.vitest.spec.ts
@@ -359,6 +359,7 @@ describe('server-state architecture', () => {
     const planController = source('src/hooks/audio/useTtsPlanController.ts');
     const playbackProjection = source('src/hooks/audio/usePlaybackProjection.ts');
     const playbackForegroundSync = source('src/hooks/audio/usePlaybackForegroundSync.ts');
+    const playbackSeek = source('src/hooks/audio/usePlaybackSeek.ts');
     const playbackControl = source('src/lib/client/tts/playback-control.ts');
     const playbackSelection = source('src/lib/client/tts/playback-selection.ts');
     const documentNavigation = source('src/hooks/audio/useTtsDocumentNavigation.ts');
@@ -576,13 +577,17 @@ describe('server-state architecture', () => {
     expect(streamSessionRoute).toContain('TTS_PLAYBACK_AHEAD_WINDOW');
     expect(streamSessionRoute).toContain('backgroundExtent');
     expect(playbackForegroundSync).toContain('subscribeTtsPlaybackEvents');
-    expect(playbackHook).toContain('postTtsPlaybackCursor');
-    // The heartbeat cursor is the playhead's projected ordinal (the same value
-    // that drives the highlight), held in playbackCursorOrdinalRef. It must NOT
-    // be re-derived from derived UI indexes. `null` => no faithful playhead yet → skip.
-    expect(playbackForegroundSync).toContain('const cursorOrdinal = playbackCursorOrdinalRef.current');
-    expect(playbackForegroundSync).toContain('if (cursorOrdinal == null) return');
-    expect(playbackForegroundSync).toContain('const cursor = Math.max(0, cursorOrdinal)');
+    expect(playbackHook).toContain('usePlaybackSeek');
+    expect(playbackForegroundSync).toContain('updateWorkerPlaybackCursor');
+    expect(playbackSeek).not.toContain('postTtsPlaybackCursor');
+    expect(playbackSeek).not.toContain('getTtsPlaybackSeekLayout');
+    expect(playbackSeek).not.toContain('setTimeout(() => { void tick(); }, 600)');
+    // Heartbeats and explicit seeks share the playhead cursor writer. It uses
+    // the projected ordinal when no seek target is supplied and never derives
+    // the cursor from UI indexes. `null` means no faithful playhead yet.
+    expect(playbackForegroundSync).toContain('const requestedOrdinal = ordinal ?? playbackCursorOrdinalRef.current');
+    expect(playbackForegroundSync).toContain('if (requestedOrdinal == null || !Number.isFinite(requestedOrdinal)) return');
+    expect(playbackForegroundSync).toContain('const cursor = Math.max(0, Math.floor(requestedOrdinal))');
     expect(context).not.toContain('const currentSegment = playbackSegmentsRef.current[currentIndexRef.current]');
     expect(playbackProjection).toContain('playbackCursorOrdinalRef.current = targetOrdinal');
     expect(playbackSelection).toContain('function pdfLocatorPage(locator: TTSSegmentLocator | null | undefined)');
@@ -618,7 +623,8 @@ describe('server-state architecture', () => {
     expect(documentNavigation).toContain("if (activeReaderType === 'pdf' || activeReaderType === 'html')");
     expect(documentNavigation).toContain('resolveFirstPlanIndexForDocumentAnchor(');
     expect(playbackHook).toContain('seekPlaybackTo');
-    expect(playbackHook).toContain('setAudioDocumentTime(audio, targetSec');
+    expect(playbackSeek).toContain('const applyReadyMediaPosition = useCallback');
+    expect(playbackSeek).toContain('setAudioDocumentTime(audio, documentTimeSec');
     expect(playbackProjection).toContain('const targetOrdinal = projection.segment.ordinal;');
     expect(playbackProjection).toContain('setSelectedOrdinal(targetOrdinal)');
     expect(playbackProjection).toContain('shouldSyncPlaybackLocator(previous?.locatorKey, locatorKey)');

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -367,7 +367,6 @@ identity and are not serialized into worker requests.
 
 `useTtsPlayback` is the media controller. It owns:
 
-- The unlocked `<audio>` element ref.
 - Playback phase state.
 - Playback session/timeline refs.
 - Playback session creation through the Next proxy.
@@ -376,6 +375,11 @@ identity and are not serialized into worker requests.
 - Timeline refresh and playback projection from `audio.currentTime`.
 - Foreground SSE sync, cursor heartbeat, visibility resync, and projection loop.
 - The in-flight playback guard and false-to-true playback driver edge.
+
+`usePlaybackAudioElement` owns the browser media primitive: creating and reusing
+the `<audio>` element, Safari/iOS gesture unlocking, playback-rate updates,
+source clearing, and unmount cleanup. Session, seek, and recovery policy remain
+in the media controller and do not leak into this browser-specific hook.
 
 Full teardown has one entrypoint: `abortAudio` invalidates the active run,
 aborts session creation, stops recovery/foreground work, and resets the session
@@ -501,10 +505,10 @@ longer send reader coordinates or text/key hints.
 
 ### 3. Extract the Playback Controller
 
-`useTtsPlayback` owns the media controller: phase, unlocked audio ref, session
-and timeline refs, playback time, stream creation, audio events, seek/resync,
-and the in-flight driver. Foreground SSE/timeline synchronization, cursor
-heartbeats, and playhead projection are delegated to focused hooks;
+`useTtsPlayback` owns the media controller: phase, session and timeline refs,
+playback time, stream creation, audio events, seek/resync, and the in-flight
+driver. Browser audio-element lifecycle, foreground SSE/timeline synchronization,
+cursor heartbeats, and playhead projection are delegated to focused hooks;
 `TTSContext` remains the app-level state/actions facade.
 
 ### 4. Collapse Duplicate Client State

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -384,7 +384,9 @@ in the media controller and do not leak into this browser-specific hook.
 `usePlaybackSeek` owns document-time targeting, generated-buffer checks, and one
 pending-seek state. Cached and not-yet-generated seeks share the same media
 positioning path. Pending readiness reacts to the seek layout already refreshed
-by foreground SSE; it does not run a second HTTP polling loop.
+by foreground SSE; it does not run a second HTTP polling loop. Its bounded
+expiry returns paused playback to ready and stops active playback with visible
+failure feedback rather than leaving the client indefinitely buffering.
 
 `usePlaybackForegroundSync` is the only client owner of worker cursor writes. It
 coalesces rapid updates to the newest ordinal, retargets the operation SSE from

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -381,6 +381,16 @@ the `<audio>` element, Safari/iOS gesture unlocking, playback-rate updates,
 source clearing, and unmount cleanup. Session, seek, and recovery policy remain
 in the media controller and do not leak into this browser-specific hook.
 
+`usePlaybackSeek` owns document-time targeting, generated-buffer checks, and one
+pending-seek state. Cached and not-yet-generated seeks share the same media
+positioning path. Pending readiness reacts to the seek layout already refreshed
+by foreground SSE; it does not run a second HTTP polling loop.
+
+`usePlaybackForegroundSync` is the only client owner of worker cursor writes. It
+coalesces rapid updates to the newest ordinal, retargets the operation SSE from
+the cursor response, and uses the same writer for the foreground heartbeat and
+explicit seeks.
+
 Full teardown has one entrypoint: `abortAudio` invalidates the active run,
 aborts session creation, stops recovery/foreground work, and resets the session
 and projection. That reset is idempotent so unmount and replacement races are

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -345,6 +345,14 @@ owns document/config inputs that are outside the media controller:
 - Settings mutations for voice, speed, provider, language, and PDF skip kinds.
 - Segment/word highlight state and current document anchor.
 - EPUB cursor-follow navigation guards.
+- Non-playback interaction busy state for navigation and settings changes.
+
+The exposed `isProcessing` value is derived from that interaction state plus the
+authoritative playback phase. The media controller does not maintain a second
+processing boolean, so a stale async callback cannot disagree with the playback
+lifecycle about whether audio is preparing, buffering, seeking, or playing.
+Planning, ready-to-start, seeking, and buffering are processing phases only while
+playback intent remains active; paused, playing, ended, failed, and idle are not.
 
 `useTtsPlaybackModel` is the single client model for worker-plan state:
 
@@ -368,6 +376,12 @@ identity and are not serialized into worker requests.
 - Timeline refresh and playback projection from `audio.currentTime`.
 - Foreground SSE sync, cursor heartbeat, visibility resync, and projection loop.
 - The in-flight playback guard and false-to-true playback driver edge.
+
+Full teardown has one entrypoint: `abortAudio` invalidates the active run,
+aborts session creation, stops recovery/foreground work, and resets the session
+and projection. That reset is idempotent so unmount and replacement races are
+safe. Pausing intentionally does not use full teardown: it preserves the active
+session and cached stream so resume does not create a new playback timeline.
 
 For EPUB specifically, the client owns only reader rendering/navigation concerns:
 


### PR DESCRIPTION
## Summary

- derive playback processing from the existing interaction and lifecycle states instead of maintaining competing manual flags
- isolate browser audio element ownership, Safari gesture unlocking, source cleanup, and playback-rate updates
- replace the independent seek polling loop with one pending-seek state driven by the existing foreground SSE read model
- centralize and coalesce worker cursor writes so heartbeats and explicit seeks share one owner
- remove obsolete header plumbing, duplicated resets, and stale seek-resync terminology
- document and guard the resulting playback ownership boundaries

## Validation

- `pnpm test` — 680 tests passed
- application and compute-worker TypeScript checks
- `pnpm build`
- route-error and compute-boundary guards
- `pnpm test:e2e` — 24 Chromium/WebKit cases passed, including both true-playback journeys

Playwright owned the only local stack during browser validation and left port 3003 free after teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved text-to-speech playback controls, including more reliable seeking, resuming, and recovery.
  - Playback processing indicators now reflect both interactions and active playback states.
  - Improved compatibility with browser autoplay restrictions, including iOS and Safari.

- **Bug Fixes**
  - Improved synchronization between playback position and document progress during rapid updates.
  - Added more consistent cleanup when playback is paused, stopped, or interrupted.
  - Playback now handles expired seeks with clearer recovery or failure feedback.

- **Documentation**
  - Updated playback architecture documentation to reflect the latest behavior and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->