### PR TITLE
feat: add play-ahead playback buffering and faster English alignment

### DIFF
--- a/packages/compute-worker/src/api/playback/session-read-model.ts
+++ b/packages/compute-worker/src/api/playback/session-read-model.ts
@@ -1,4 +1,3 @@
-import { buildProportionalAlignment } from '@openreader/tts/segments';
 import type { ArtifactStorage } from '../../infrastructure/storage';
 import { toErrorMessage } from '../../infrastructure/errors';
 import type {
@@ -20,7 +19,7 @@ export type PlaybackSegmentManifestRow = {
   audioKey: string;
   durationMs: number;
   alignmentJson: string | null;
-  alignmentSource: 'proportional' | 'exact' | null;
+  alignmentSource: 'exact' | null;
   updatedAt: number | null;
 };
 
@@ -55,16 +54,8 @@ function isStableCompletedSidecar(
   return sidecar?.status === 'completed' && Boolean(sidecar.alignment);
 }
 
-function readSessionLanguage(settingsJson: unknown): string | undefined {
-  if (!settingsJson || typeof settingsJson !== 'object') return undefined;
-  const language = Reflect.get(settingsJson, 'language');
-  return typeof language === 'string' && language.trim() ? language : undefined;
-}
-
 function serializeTimelineAlignment(input: {
   sidecar: TtsPlaybackSegmentMetadata;
-  text: string | undefined;
-  language: string | undefined;
 }): Pick<PlaybackSegmentManifestRow, 'alignmentJson' | 'alignmentSource'> {
   if (input.sidecar.alignment) {
     return {
@@ -72,19 +63,7 @@ function serializeTimelineAlignment(input: {
       alignmentSource: 'exact',
     };
   }
-  const durationMs = Number(input.sidecar.durationMs);
-  if (!input.text || !Number.isFinite(durationMs) || durationMs <= 0) {
-    return { alignmentJson: null, alignmentSource: null };
-  }
-  const alignment = buildProportionalAlignment({
-    sentence: input.text,
-    sentenceIndex: input.sidecar.ordinal,
-    durationMs,
-    language: input.language,
-  });
-  return alignment.words.length > 0
-    ? { alignmentJson: JSON.stringify(alignment), alignmentSource: 'proportional' }
-    : { alignmentJson: null, alignmentSource: null };
+  return { alignmentJson: null, alignmentSource: null };
 }
 
 function scopeCacheKey(session: PlaybackSessionRow, cacheEpoch: number): string {
@@ -185,7 +164,7 @@ export function createPlaybackSessionReadModel(input: {
       // List only this user/document/version/settings prefix. A deep cursor
       // must not turn thousands of ungenerated ordinals into serial S3 batches.
       // Existing exact timing remains cached across chapter changes; unfinished
-      // sidecars are re-read so proportional timing upgrades to exact timing.
+      // sidecars are re-read so exact timing can appear as soon as it exists.
       const ordinals = (await playbackStorage?.artifacts.listSegmentOrdinals(session).catch((error) => {
         logger?.warn({
           sessionId: session.sessionId,
@@ -253,8 +232,6 @@ export function createPlaybackSessionReadModel(input: {
       if (!session.planObjectKey) return [];
       const planSegments = await readPlanSegments(session.planObjectKey);
       if (!planSegments?.length) return [];
-      const planTextByOrdinal = new Map(planSegments.map((segment) => [segment.ordinal, segment.text]));
-      const language = readSessionLanguage(session.settingsJson);
       if (!options) {
         const sidecars = await collectScopeSidecars(session, planSegments.length);
         return [...sidecars.values()]
@@ -266,11 +243,7 @@ export function createPlaybackSessionReadModel(input: {
             segmentKey: sidecar.segmentKey,
             audioKey: sidecar.audioKey,
             durationMs: Math.max(1, Number(sidecar.durationMs ?? 1000)),
-            ...serializeTimelineAlignment({
-              sidecar,
-              text: planTextByOrdinal.get(sidecar.ordinal),
-              language,
-            }),
+            ...serializeTimelineAlignment({ sidecar }),
             updatedAt: sidecar.updatedAt ?? null,
           }))
           .sort((left, right) => left.ordinal - right.ordinal);
@@ -310,12 +283,8 @@ export function createPlaybackSessionReadModel(input: {
           ordinal: sidecar.ordinal,
           segmentKey: sidecar.segmentKey,
           audioKey: sidecar.audioKey,
-          durationMs: Math.max(1, Number(sidecar.durationMs ?? 1000)),
-          ...serializeTimelineAlignment({
-            sidecar,
-            text: planTextByOrdinal.get(sidecar.ordinal),
-            language,
-          }),
+            durationMs: Math.max(1, Number(sidecar.durationMs ?? 1000)),
+            ...serializeTimelineAlignment({ sidecar }),
           updatedAt: sidecar.updatedAt ?? null,
         }))
         .sort((left, right) => left.ordinal - right.ordinal);

--- a/packages/compute-worker/src/inference/runtime.ts
+++ b/packages/compute-worker/src/inference/runtime.ts
@@ -5,7 +5,10 @@ import { parsePdf } from './pdf/parse';
 import type { ModelDownloadProgressHandler } from './model-download';
 
 export async function ensureComputeModels(): Promise<void> {
-  await Promise.all([ensureWhisperModel(), ensurePdfLayoutModel()]);
+  await Promise.all([
+    ensureWhisperModel({ variant: 'tiny-english' }),
+    ensurePdfLayoutModel(),
+  ]);
 }
 
 export async function runWhisperAlignmentFromAudioBuffer(input: {

--- a/packages/compute-worker/src/inference/whisper/align.ts
+++ b/packages/compute-worker/src/inference/whisper/align.ts
@@ -21,13 +21,9 @@ import {
 } from './timestamps';
 import {
   ensureWhisperModel,
-  WHISPER_CONFIG_PATH,
-  WHISPER_GENERATION_CONFIG_PATH,
-  WHISPER_TOKENIZER_CONFIG_PATH,
-  WHISPER_TOKENIZER_PATH,
-  WHISPER_ENCODER_MODEL_PATH,
-  WHISPER_DECODER_MERGED_MODEL_PATH,
-  WHISPER_DECODER_WITH_PAST_MODEL_PATH,
+  getWhisperModelPaths,
+  resolveWhisperModelVariant,
+  type WhisperModelVariant,
 } from './model';
 import {
   applyTokenSuppression,
@@ -64,6 +60,7 @@ interface WhisperAlignmentOptions {
 }
 
 interface WhisperRuntime {
+  variant: WhisperModelVariant;
   encoder: ort.InferenceSession;
   decoderMerged: ort.InferenceSession;
   decoderWithPast: ort.InferenceSession;
@@ -81,18 +78,23 @@ interface WhisperRuntime {
   alignmentHeads: Array<[number, number]>;
   prefillFetches: string[];
   stepFetches: string[];
+  isMultilingual: boolean;
+  decoderLayers: number;
+  decoderAttentionHeads: number;
+  decoderHeadDim: number;
+  encoderSequenceLength: number;
 }
 
 type WhisperAlignmentState = {
   alignmentCache: Map<string, TTSSentenceAlignment[]>;
   alignmentInFlight: Map<string, Promise<TTSSentenceAlignment[]>>;
-  runtimePromise: Promise<WhisperRuntime> | null;
+  runtimePromises: Map<WhisperModelVariant, Promise<WhisperRuntime>>;
   alignmentLaneTail: Promise<void>;
   officialMelFilters: Float32Array[] | null;
-  emptyPastFeedsTemplate: Record<string, ort.Tensor> | null;
+  emptyPastFeedsTemplates: Map<WhisperModelVariant, Record<string, ort.Tensor>>;
 };
 
-const WHISPER_ALIGNMENT_STATE_KEY = '__openreaderWhisperAlignmentStateV1';
+const WHISPER_ALIGNMENT_STATE_KEY = '__openreaderWhisperAlignmentStateV2';
 const g = globalThis as typeof globalThis & Record<string, unknown>;
 const state = (() => {
   const existing = g[WHISPER_ALIGNMENT_STATE_KEY] as WhisperAlignmentState | undefined;
@@ -103,10 +105,10 @@ const state = (() => {
   const created: WhisperAlignmentState = {
     alignmentCache: new Map<string, TTSSentenceAlignment[]>(),
     alignmentInFlight: new Map<string, Promise<TTSSentenceAlignment[]>>(),
-    runtimePromise: null,
+    runtimePromises: new Map(),
     alignmentLaneTail: Promise.resolve(),
     officialMelFilters: null,
-    emptyPastFeedsTemplate: null,
+    emptyPastFeedsTemplates: new Map(),
   };
   g[WHISPER_ALIGNMENT_STATE_KEY] = created;
   return created;
@@ -127,9 +129,6 @@ const CHUNK_LENGTH_SECONDS = 30;
 const N_SAMPLES = CHUNK_LENGTH_SECONDS * SAMPLE_RATE;
 const N_FRAMES = N_SAMPLES / HOP_LENGTH;
 const N_MELS = 80;
-const WHISPER_NUM_HEADS = 8;
-const WHISPER_HEAD_DIM = 64;
-const WHISPER_NUM_LAYERS = 6;
 const MEL_FILTER_BINS = (N_FFT / 2) + 1;
 
 const hannWindow = buildHannWindow(N_FFT);
@@ -433,44 +432,67 @@ function makeInFlightCoalesceKey(audioBuffer: TTSAudioBuffer, text: string, lang
     .digest('hex');
 }
 
-function buildEmptyPastFeeds() {
-  if (state.emptyPastFeedsTemplate) return state.emptyPastFeedsTemplate;
+function buildEmptyPastFeeds(runtime: WhisperRuntime) {
+  const cached = state.emptyPastFeedsTemplates.get(runtime.variant);
+  if (cached) return cached;
 
   const feeds: Record<string, ort.Tensor> = {};
   const emptyDecoderPast = new Float32Array(0);
-  const emptyEncoderPast = new Float32Array(1 * WHISPER_NUM_HEADS * 1500 * WHISPER_HEAD_DIM);
+  const emptyEncoderPast = new Float32Array(
+    runtime.decoderAttentionHeads * runtime.encoderSequenceLength * runtime.decoderHeadDim,
+  );
 
-  for (let i = 0; i < WHISPER_NUM_LAYERS; i += 1) {
-    feeds[`past_key_values.${i}.decoder.key`] = new ort.Tensor('float32', emptyDecoderPast, [1, WHISPER_NUM_HEADS, 0, WHISPER_HEAD_DIM]);
-    feeds[`past_key_values.${i}.decoder.value`] = new ort.Tensor('float32', emptyDecoderPast, [1, WHISPER_NUM_HEADS, 0, WHISPER_HEAD_DIM]);
+  for (let i = 0; i < runtime.decoderLayers; i += 1) {
+    feeds[`past_key_values.${i}.decoder.key`] = new ort.Tensor(
+      'float32', emptyDecoderPast, [1, runtime.decoderAttentionHeads, 0, runtime.decoderHeadDim],
+    );
+    feeds[`past_key_values.${i}.decoder.value`] = new ort.Tensor(
+      'float32', emptyDecoderPast, [1, runtime.decoderAttentionHeads, 0, runtime.decoderHeadDim],
+    );
 
     // First pass still expects encoder KV inputs in the merged decoder graph.
-    feeds[`past_key_values.${i}.encoder.key`] = new ort.Tensor('float32', emptyEncoderPast, [1, WHISPER_NUM_HEADS, 1500, WHISPER_HEAD_DIM]);
-    feeds[`past_key_values.${i}.encoder.value`] = new ort.Tensor('float32', emptyEncoderPast, [1, WHISPER_NUM_HEADS, 1500, WHISPER_HEAD_DIM]);
+    feeds[`past_key_values.${i}.encoder.key`] = new ort.Tensor(
+      'float32', emptyEncoderPast,
+      [1, runtime.decoderAttentionHeads, runtime.encoderSequenceLength, runtime.decoderHeadDim],
+    );
+    feeds[`past_key_values.${i}.encoder.value`] = new ort.Tensor(
+      'float32', emptyEncoderPast,
+      [1, runtime.decoderAttentionHeads, runtime.encoderSequenceLength, runtime.decoderHeadDim],
+    );
   }
 
-  state.emptyPastFeedsTemplate = feeds;
-  return state.emptyPastFeedsTemplate;
+  state.emptyPastFeedsTemplates.set(runtime.variant, feeds);
+  return feeds;
 }
 
-async function getRuntime(onModelDownloadProgress?: ModelDownloadProgressHandler): Promise<WhisperRuntime> {
-  if (state.runtimePromise) return state.runtimePromise;
+async function getRuntime(
+  language?: string,
+  onModelDownloadProgress?: ModelDownloadProgressHandler,
+): Promise<WhisperRuntime> {
+  const variant = resolveWhisperModelVariant(language);
+  const existing = state.runtimePromises.get(variant);
+  if (existing) return existing;
 
-  state.runtimePromise = (async () => {
-    await ensureWhisperModel({ onProgress: onModelDownloadProgress });
+  const runtimePromise = (async () => {
+    await ensureWhisperModel({ variant, onProgress: onModelDownloadProgress });
     await loadOfficialMelFilters();
+    const paths = getWhisperModelPaths(variant);
 
     const [configRaw, generationRaw, tokenizerJsonRaw, tokenizerConfigRaw] = await Promise.all([
-      readFile(WHISPER_CONFIG_PATH, 'utf8'),
-      readFile(WHISPER_GENERATION_CONFIG_PATH, 'utf8'),
-      readFile(WHISPER_TOKENIZER_PATH, 'utf8'),
-      readFile(WHISPER_TOKENIZER_CONFIG_PATH, 'utf8'),
+      readFile(paths.configPath, 'utf8'),
+      readFile(paths.generationConfigPath, 'utf8'),
+      readFile(paths.tokenizerPath, 'utf8'),
+      readFile(paths.tokenizerConfigPath, 'utf8'),
     ]);
 
     const config = JSON.parse(configRaw) as {
       decoder_start_token_id?: number;
       eos_token_id?: number;
       forced_decoder_ids?: Array<[number, number | null]>;
+      decoder_layers?: number;
+      decoder_attention_heads?: number;
+      d_model?: number;
+      max_source_positions?: number;
     };
 
     const generationConfig = JSON.parse(generationRaw) as {
@@ -480,9 +502,20 @@ async function getRuntime(onModelDownloadProgress?: ModelDownloadProgressHandler
       begin_suppress_tokens?: number[];
       max_length?: number;
       alignment_heads?: Array<[number, number]>;
+      is_multilingual?: boolean;
     };
 
     const tokenizer = new Tokenizer(JSON.parse(tokenizerJsonRaw), JSON.parse(tokenizerConfigRaw));
+    const decoderLayers = Number(config.decoder_layers);
+    const decoderAttentionHeads = Number(config.decoder_attention_heads);
+    const dModel = Number(config.d_model);
+    const encoderSequenceLength = Number(config.max_source_positions ?? 1500);
+    if (!Number.isInteger(decoderLayers) || decoderLayers <= 0
+      || !Number.isInteger(decoderAttentionHeads) || decoderAttentionHeads <= 0
+      || !Number.isInteger(dModel) || dModel <= 0 || dModel % decoderAttentionHeads !== 0
+      || !Number.isInteger(encoderSequenceLength) || encoderSequenceLength <= 0) {
+      throw new Error(`Whisper ${variant} configuration has invalid decoder dimensions`);
+    }
 
     const promptStartToken = Number(config.decoder_start_token_id ?? 50258);
     const eosTokenId = Number(config.eos_token_id ?? 50257);
@@ -515,9 +548,9 @@ async function getRuntime(onModelDownloadProgress?: ModelDownloadProgressHandler
       executionMode: 'sequential',
     };
 
-    const encoder = await ort.InferenceSession.create(WHISPER_ENCODER_MODEL_PATH, stableSessionOptions);
-    const decoderMerged = await ort.InferenceSession.create(WHISPER_DECODER_MERGED_MODEL_PATH, stableSessionOptions);
-    const decoderWithPast = await ort.InferenceSession.create(WHISPER_DECODER_WITH_PAST_MODEL_PATH, stableSessionOptions);
+    const encoder = await ort.InferenceSession.create(paths.encoderModelPath, stableSessionOptions);
+    const decoderMerged = await ort.InferenceSession.create(paths.decoderMergedModelPath, stableSessionOptions);
+    const decoderWithPast = await ort.InferenceSession.create(paths.decoderWithPastModelPath, stableSessionOptions);
 
     const alignmentLayers = [...new Set(alignmentHeads.map(([layer]) => layer))];
     const prefillFetches: string[] = ['logits'];
@@ -525,7 +558,7 @@ async function getRuntime(onModelDownloadProgress?: ModelDownloadProgressHandler
     const mergedOutputNames = new Set(decoderMerged.outputNames);
     const withPastOutputNames = new Set(decoderWithPast.outputNames);
 
-    for (let i = 0; i < WHISPER_NUM_LAYERS; i += 1) {
+    for (let i = 0; i < decoderLayers; i += 1) {
       const decoderKey = `present.${i}.decoder.key`;
       const decoderValue = `present.${i}.decoder.value`;
       if (mergedOutputNames.has(decoderKey)) prefillFetches.push(decoderKey);
@@ -546,6 +579,7 @@ async function getRuntime(onModelDownloadProgress?: ModelDownloadProgressHandler
     }
 
     return {
+      variant,
       encoder,
       decoderMerged,
       decoderWithPast,
@@ -563,13 +597,19 @@ async function getRuntime(onModelDownloadProgress?: ModelDownloadProgressHandler
       alignmentHeads,
       prefillFetches,
       stepFetches,
+      isMultilingual: generationConfig.is_multilingual !== false,
+      decoderLayers,
+      decoderAttentionHeads,
+      decoderHeadDim: dModel / decoderAttentionHeads,
+      encoderSequenceLength,
     };
   })().catch((error) => {
-    state.runtimePromise = null;
+    state.runtimePromises.delete(variant);
     throw error;
   });
 
-  return state.runtimePromise;
+  state.runtimePromises.set(variant, runtimePromise);
+  return runtimePromise;
 }
 
 function resolveLanguageToken(runtime: WhisperRuntime, lang?: string): number {
@@ -588,7 +628,7 @@ async function runWhisperOnnx(
   timeoutMs: number,
 ): Promise<WhisperWord[]> {
   assertWithinDeadline(deadlineMs, timeoutMs);
-  const runtime = await getRuntime(opts.onModelDownloadProgress);
+  const runtime = await getRuntime(opts.lang, opts.onModelDownloadProgress);
   const decodeStepLimit = computeAdaptiveDecodeStepLimit(runtime.maxDecodeSteps, opts.textHint);
   const mel = computeLogMelSpectrogram(audioSamples);
   const encoderPast: Record<string, ort.Tensor> = {};
@@ -603,15 +643,16 @@ async function runWhisperOnnx(
     }, ['last_hidden_state']);
     encoderHidden = encoderOutputs.last_hidden_state;
 
-    const languageToken = resolveLanguageToken(runtime, opts.lang);
-    const promptTokens = [
-      runtime.promptStartToken,
-      languageToken,
-      runtime.transcribeToken,
-    ];
+    const promptTokens = runtime.isMultilingual
+      ? [
+          runtime.promptStartToken,
+          resolveLanguageToken(runtime, opts.lang),
+          runtime.transcribeToken,
+        ]
+      : [runtime.promptStartToken];
 
     const generated: number[] = [...promptTokens];
-    const emptyPastFeeds = buildEmptyPastFeeds();
+    const emptyPastFeeds = buildEmptyPastFeeds(runtime);
     type LayerChunk = {
       data: Float32Array;
       heads: number;
@@ -677,7 +718,7 @@ async function runWhisperOnnx(
     }
     captureCrossAttentions(outputs, true);
 
-    for (let i = 0; i < WHISPER_NUM_LAYERS; i += 1) {
+    for (let i = 0; i < runtime.decoderLayers; i += 1) {
       encoderPast[`past_key_values.${i}.encoder.key`] = outputs[`present.${i}.encoder.key`];
       encoderPast[`past_key_values.${i}.encoder.value`] = outputs[`present.${i}.encoder.value`];
       decoderPast[`past_key_values.${i}.decoder.key`] = outputs[`present.${i}.decoder.key`];
@@ -727,7 +768,7 @@ async function runWhisperOnnx(
       }
       captureCrossAttentions(nextOutputs, false);
 
-      for (let i = 0; i < WHISPER_NUM_LAYERS; i += 1) {
+      for (let i = 0; i < runtime.decoderLayers; i += 1) {
         decoderPast[`past_key_values.${i}.decoder.key`] = nextOutputs[`present.${i}.decoder.key`];
         decoderPast[`past_key_values.${i}.decoder.value`] = nextOutputs[`present.${i}.decoder.value`];
       }
@@ -755,7 +796,7 @@ async function runWhisperOnnx(
       })
       .filter((pair): pair is [number, number] => pair !== null);
 
-    for (let layer = 0; layer < WHISPER_NUM_LAYERS; layer += 1) {
+    for (let layer = 0; layer < runtime.decoderLayers; layer += 1) {
       const chunks = crossAttentionChunks.get(layer);
       if (!chunks || !chunks.length) continue;
 
@@ -786,7 +827,7 @@ async function runWhisperOnnx(
 
     const tokenStartTimestamps = extractTokenStartTimestamps({
       crossAttentions,
-      decoderLayers: WHISPER_NUM_LAYERS,
+      decoderLayers: runtime.decoderLayers,
       alignmentHeads: remappedAlignmentHeads,
       numFrames,
       numInputIds: promptTokens.length,
@@ -835,19 +876,21 @@ export async function alignAudioWithText(
   opts: WhisperAlignmentOptions = {},
 ): Promise<TTSSentenceAlignment[]> {
   if (!text.trim()) return [];
+  const modelVariant = resolveWhisperModelVariant(opts.lang);
+  const scopedCacheKey = cacheKey ? `${modelVariant}:${cacheKey}` : null;
 
-  if (cacheKey && alignmentCache.has(cacheKey)) {
-    const cached = alignmentCache.get(cacheKey)!;
-    alignmentCache.delete(cacheKey);
-    alignmentCache.set(cacheKey, cached);
+  if (scopedCacheKey && alignmentCache.has(scopedCacheKey)) {
+    const cached = alignmentCache.get(scopedCacheKey)!;
+    alignmentCache.delete(scopedCacheKey);
+    alignmentCache.set(scopedCacheKey, cached);
     return cached;
   }
 
-  if (cacheKey) {
-    const inFlight = alignmentInFlight.get(cacheKey);
+  if (scopedCacheKey) {
+    const inFlight = alignmentInFlight.get(scopedCacheKey);
     if (inFlight) return inFlight;
   }
-  const inFlightKey = cacheKey ?? makeInFlightCoalesceKey(audioBuffer, text, opts.lang);
+  const inFlightKey = scopedCacheKey ?? makeInFlightCoalesceKey(audioBuffer, text, opts.lang);
   const shared = alignmentInFlight.get(inFlightKey);
   if (shared) return shared;
 
@@ -883,11 +926,11 @@ export async function alignAudioWithText(
       const alignment = mapWordsToSentenceOffsets(text, words);
       const result: TTSSentenceAlignment[] = [alignment];
 
-      if (cacheKey) {
-        if (alignmentCache.has(cacheKey)) {
-          alignmentCache.delete(cacheKey);
+      if (scopedCacheKey) {
+        if (alignmentCache.has(scopedCacheKey)) {
+          alignmentCache.delete(scopedCacheKey);
         }
-        alignmentCache.set(cacheKey, result);
+        alignmentCache.set(scopedCacheKey, result);
         while (alignmentCache.size > ALIGNMENT_CACHE_MAX_ENTRIES) {
           const oldest = alignmentCache.keys().next().value;
           if (!oldest) break;

--- a/packages/compute-worker/src/inference/whisper/assets/tiny-en-manifest.json
+++ b/packages/compute-worker/src/inference/whisper/assets/tiny-en-manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "whisper-tiny.en_timestamped-q4",
+  "version": "onnx-community/whisper-tiny.en_timestamped@aeaa13760958b03fac5062f457d317d3319c3168",
+  "files": [
+    { "path": "config.json", "sha256": "251ea843b5901a99efa58c0b99b8052c6019aa3e7d2baf46693a1128ff606233", "size": 2197 },
+    { "path": "generation_config.json", "sha256": "7b2e8451ed5f118e75fdd991409d72119d21d2fef1eba9723f68fb9c57fe5dc9", "size": 1646 },
+    { "path": "tokenizer.json", "sha256": "5eb60cec1e77aeeb6869a2bb5a8e01a84c3fe5d072d75369343021fe6f5310d0", "size": 2405679 },
+    { "path": "tokenizer_config.json", "sha256": "93879c3dccdd4b976f709acd85b44778873f30c275e67026f30ca1e4c975230c", "size": 282662 },
+    { "path": "merges.txt", "sha256": "1ce1664773c50f3e0cc8842619a93edc4624525b728b188a9e0be33b7726adc5", "size": 456318 },
+    { "path": "vocab.json", "sha256": "f6bd25a65e4e63ca31360e9fb11c7e4f9a391a78385d640acd814092dd6eee4f", "size": 999186 },
+    { "path": "normalizer.json", "sha256": "bf1c507dc8724ca9cf9903640dacfb69dae2f00edee4f21ceba106a7392f26dd", "size": 52666 },
+    { "path": "added_tokens.json", "sha256": "560be47bea388757f8d4cc185c5d82067426cbb6361e38016dd90ddc01ab203a", "size": 34604 },
+    { "path": "preprocessor_config.json", "sha256": "a6a76d28c93edb273669eb9e0b0636a2bddbb1272c3261e47b7ca6dfdbac1b8d", "size": 339 },
+    { "path": "special_tokens_map.json", "sha256": "98bdf3ec5b32e31575b02f64b0a32bde7c0449075d34484a7df9bdd3cdeb9fb9", "size": 2173 },
+    { "path": "onnx/encoder_model_q4.onnx", "sha256": "fae0e8f5bec746964775faf00ea2ddf49a52f408550384a49f3394b31633c15f", "size": 9019892 },
+    { "path": "onnx/decoder_model_merged_q4.onnx", "sha256": "19885c31b799d9a4387be37bc85bbf856b2f1b93f525b9b0a2d66aaad8d8a37f", "size": 86803045 },
+    { "path": "onnx/decoder_with_past_model_q4.onnx", "sha256": "a9876aef9500c6731312f348c630a7503a0ac0e3efedadeade9cf4abf35acf4a", "size": 85800961 },
+    { "path": "LICENSE.txt", "sha256": "b5d65a59060e68c4ff940e1eddfa6f94b2d68fdf58ed7f4dd57721c997e35e9d", "size": 1063 }
+  ]
+}

--- a/packages/compute-worker/src/inference/whisper/model.ts
+++ b/packages/compute-worker/src/inference/whisper/model.ts
@@ -10,52 +10,32 @@ import {
 } from '../model-download';
 
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
-const MODEL_DIR = path.join(DOCSTORE_DIR, 'model', 'whisper-base_timestamped');
 const STATIC_LICENSE_PATH = path.join(MODULE_DIR, 'assets', 'LICENSE.txt');
-const MANIFEST_PATH = path.join(MODULE_DIR, 'assets', 'manifest.json');
+const BASE_MANIFEST_PATH = path.join(MODULE_DIR, 'assets', 'manifest.json');
+const TINY_EN_MANIFEST_PATH = path.join(MODULE_DIR, 'assets', 'tiny-en-manifest.json');
 
-export const WHISPER_CONFIG_PATH = path.join(MODEL_DIR, 'config.json');
-export const WHISPER_GENERATION_CONFIG_PATH = path.join(MODEL_DIR, 'generation_config.json');
-export const WHISPER_TOKENIZER_PATH = path.join(MODEL_DIR, 'tokenizer.json');
-export const WHISPER_TOKENIZER_CONFIG_PATH = path.join(MODEL_DIR, 'tokenizer_config.json');
-export const WHISPER_ENCODER_MODEL_PATH = path.join(MODEL_DIR, 'onnx', 'encoder_model_q4.onnx');
-export const WHISPER_DECODER_MERGED_MODEL_PATH = path.join(MODEL_DIR, 'onnx', 'decoder_model_merged_q4.onnx');
-export const WHISPER_DECODER_WITH_PAST_MODEL_PATH = path.join(MODEL_DIR, 'onnx', 'decoder_with_past_model_q4.onnx');
+export type WhisperModelVariant = 'base-multilingual' | 'tiny-english';
 
-const BASE_MODEL_URL = 'https://huggingface.co/onnx-community/whisper-base_timestamped/resolve/main';
-const WHISPER_MODEL_BASE_URL_ENV = 'WHISPER_MODEL_BASE_URL';
-
-const MODEL_RELATIVE_PATHS: string[] = [
-  'config.json',
-  'generation_config.json',
-  'tokenizer.json',
-  'tokenizer_config.json',
-  'merges.txt',
-  'vocab.json',
-  'normalizer.json',
-  'added_tokens.json',
-  'preprocessor_config.json',
-  'special_tokens_map.json',
-  'onnx/encoder_model_q4.onnx',
-  'onnx/decoder_model_merged_q4.onnx',
-  'onnx/decoder_with_past_model_q4.onnx',
-];
-
-const DEFAULT_URLS: Record<string, string> = {
-  'config.json': `${BASE_MODEL_URL}/config.json`,
-  'generation_config.json': `${BASE_MODEL_URL}/generation_config.json`,
-  'tokenizer.json': `${BASE_MODEL_URL}/tokenizer.json`,
-  'tokenizer_config.json': `${BASE_MODEL_URL}/tokenizer_config.json`,
-  'merges.txt': `${BASE_MODEL_URL}/merges.txt`,
-  'vocab.json': `${BASE_MODEL_URL}/vocab.json`,
-  'normalizer.json': `${BASE_MODEL_URL}/normalizer.json`,
-  'added_tokens.json': `${BASE_MODEL_URL}/added_tokens.json`,
-  'preprocessor_config.json': `${BASE_MODEL_URL}/preprocessor_config.json`,
-  'special_tokens_map.json': `${BASE_MODEL_URL}/special_tokens_map.json`,
-  'onnx/encoder_model_q4.onnx': `${BASE_MODEL_URL}/onnx/encoder_model_q4.onnx`,
-  'onnx/decoder_model_merged_q4.onnx': `${BASE_MODEL_URL}/onnx/decoder_model_merged_q4.onnx`,
-  'onnx/decoder_with_past_model_q4.onnx': `${BASE_MODEL_URL}/onnx/decoder_with_past_model_q4.onnx`,
+type WhisperModelSpec = {
+  directoryName: string;
+  manifestPath: string;
+  baseUrl: string;
 };
+
+const MODEL_SPECS: Record<WhisperModelVariant, WhisperModelSpec> = {
+  'base-multilingual': {
+    directoryName: 'whisper-base_timestamped',
+    manifestPath: BASE_MANIFEST_PATH,
+    baseUrl: 'https://huggingface.co/onnx-community/whisper-base_timestamped/resolve/main',
+  },
+  'tiny-english': {
+    directoryName: 'whisper-tiny.en_timestamped',
+    manifestPath: TINY_EN_MANIFEST_PATH,
+    baseUrl: 'https://huggingface.co/onnx-community/whisper-tiny.en_timestamped/resolve/aeaa13760958b03fac5062f457d317d3319c3168',
+  },
+};
+
+const WHISPER_MODEL_BASE_URL_ENV = 'WHISPER_MODEL_BASE_URL';
 
 type ManifestEntry = { path: string; sha256?: string; size?: number };
 
@@ -75,15 +55,11 @@ export interface WhisperStaticArtifactSpec {
 
 export type WhisperFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
-function loadManifestFiles(): ManifestEntry[] {
-  const manifestText = readFileSync(MANIFEST_PATH, 'utf8');
+function loadManifestFiles(manifestPath: string): ManifestEntry[] {
+  const manifestText = readFileSync(manifestPath, 'utf8');
   const parsed = JSON.parse(manifestText) as { files?: ManifestEntry[] };
   return Array.isArray(parsed.files) ? parsed.files : [];
 }
-
-const MANIFEST_FILES = loadManifestFiles();
-const MODEL_FILES = MANIFEST_FILES.filter((entry) => entry.path !== 'LICENSE.txt');
-const LICENSE_FILE = MANIFEST_FILES.find((entry) => entry.path === 'LICENSE.txt');
 
 function normalizeExpected(entry: { sha256?: string; size?: number }): { sha256: string | null; size: number } {
   return {
@@ -100,16 +76,11 @@ function joinModelUrl(baseUrl: string, relativePath: string): string {
   return `${baseUrl.replace(/\/+$/, '')}/${relativePath}`;
 }
 
-function resolveUrl(relativePath: string): string {
-  const overrideBase = process.env[WHISPER_MODEL_BASE_URL_ENV]?.trim();
-  if (overrideBase) {
-    return joinModelUrl(overrideBase, relativePath);
-  }
-  const fallback = DEFAULT_URLS[relativePath];
-  if (!fallback) {
-    throw new Error(`No default URL configured for Whisper model artifact: ${relativePath}`);
-  }
-  return fallback;
+function resolveUrl(variant: WhisperModelVariant, relativePath: string): string {
+  const overrideBase = variant === 'base-multilingual'
+    ? process.env[WHISPER_MODEL_BASE_URL_ENV]?.trim()
+    : null;
+  return joinModelUrl(overrideBase || MODEL_SPECS[variant].baseUrl, relativePath);
 }
 
 function sha256OfBytes(bytes: Uint8Array): string {
@@ -209,56 +180,95 @@ export async function ensureWhisperArtifacts(options: {
   }
 }
 
-async function ensureModelInternal(onProgress?: ModelDownloadProgressHandler): Promise<string> {
-  if (process.env[WHISPER_MODEL_BASE_URL_ENV]?.trim()) {
-    for (const relativePath of MODEL_RELATIVE_PATHS) {
-      if (!(relativePath in DEFAULT_URLS)) {
-        throw new Error(`Missing default URL path mapping for Whisper artifact: ${relativePath}`);
-      }
-    }
-  }
+export function resolveWhisperModelVariant(language?: string): WhisperModelVariant {
+  const baseLanguage = language?.trim().toLowerCase().split(/[-_]/, 1)[0] ?? '';
+  return baseLanguage === 'en' ? 'tiny-english' : 'base-multilingual';
+}
 
-  const artifacts: WhisperArtifactSpec[] = MODEL_FILES.map((entry) => ({
+export type WhisperModelPaths = {
+  modelDir: string;
+  configPath: string;
+  generationConfigPath: string;
+  tokenizerPath: string;
+  tokenizerConfigPath: string;
+  encoderModelPath: string;
+  decoderMergedModelPath: string;
+  decoderWithPastModelPath: string;
+};
+
+export function getWhisperModelPaths(variant: WhisperModelVariant): WhisperModelPaths {
+  const modelDir = path.join(DOCSTORE_DIR, 'model', MODEL_SPECS[variant].directoryName);
+  return {
+    modelDir,
+    configPath: path.join(modelDir, 'config.json'),
+    generationConfigPath: path.join(modelDir, 'generation_config.json'),
+    tokenizerPath: path.join(modelDir, 'tokenizer.json'),
+    tokenizerConfigPath: path.join(modelDir, 'tokenizer_config.json'),
+    encoderModelPath: path.join(modelDir, 'onnx', 'encoder_model_q4.onnx'),
+    decoderMergedModelPath: path.join(modelDir, 'onnx', 'decoder_model_merged_q4.onnx'),
+    decoderWithPastModelPath: path.join(modelDir, 'onnx', 'decoder_with_past_model_q4.onnx'),
+  };
+}
+
+async function ensureModelInternal(
+  variant: WhisperModelVariant,
+  onProgress?: ModelDownloadProgressHandler,
+): Promise<string> {
+  const spec = MODEL_SPECS[variant];
+  const paths = getWhisperModelPaths(variant);
+  const manifestFiles = loadManifestFiles(spec.manifestPath);
+  const modelFiles = manifestFiles.filter((entry) => entry.path !== 'LICENSE.txt');
+  const licenseFile = manifestFiles.find((entry) => entry.path === 'LICENSE.txt');
+
+  const artifacts: WhisperArtifactSpec[] = modelFiles.map((entry) => ({
     path: entry.path,
     sha256: entry.sha256,
     size: entry.size,
-    url: resolveUrl(entry.path),
+    url: resolveUrl(variant, entry.path),
   }));
 
-  const staticArtifacts: WhisperStaticArtifactSpec[] = LICENSE_FILE
+  const staticArtifacts: WhisperStaticArtifactSpec[] = licenseFile
     ? [{
-        path: LICENSE_FILE.path,
-        sha256: LICENSE_FILE.sha256,
-        size: LICENSE_FILE.size,
+        path: licenseFile.path,
+        sha256: licenseFile.sha256,
+        size: licenseFile.size,
         sourcePath: STATIC_LICENSE_PATH,
       }]
     : [];
 
   await ensureWhisperArtifacts({
-    modelDir: MODEL_DIR,
+    modelDir: paths.modelDir,
     artifacts,
     staticArtifacts,
     onProgress,
   });
 
-  return WHISPER_ENCODER_MODEL_PATH;
+  return paths.encoderModelPath;
 }
 
-let ensureWhisperModelInflight: Promise<string> | null = null;
-const progressListeners = new Set<ModelDownloadProgressHandler>();
+const ensureWhisperModelInflight = new Map<WhisperModelVariant, Promise<string>>();
+const progressListeners = new Map<WhisperModelVariant, Set<ModelDownloadProgressHandler>>();
 
-export async function ensureWhisperModel(options: { onProgress?: ModelDownloadProgressHandler } = {}): Promise<string> {
-  if (options.onProgress) progressListeners.add(options.onProgress);
-  if (!ensureWhisperModelInflight) {
-    ensureWhisperModelInflight = ensureModelInternal(async (progress) => {
-      await Promise.all([...progressListeners].map((listener) => listener(progress)));
+export async function ensureWhisperModel(options: {
+  variant?: WhisperModelVariant;
+  onProgress?: ModelDownloadProgressHandler;
+} = {}): Promise<string> {
+  const variant = options.variant ?? 'base-multilingual';
+  const listeners = progressListeners.get(variant) ?? new Set<ModelDownloadProgressHandler>();
+  progressListeners.set(variant, listeners);
+  if (options.onProgress) listeners.add(options.onProgress);
+  if (!ensureWhisperModelInflight.has(variant)) {
+    const pending = ensureModelInternal(variant, async (progress) => {
+      await Promise.all([...listeners].map((listener) => listener(progress)));
     }).finally(() => {
-      ensureWhisperModelInflight = null;
+      ensureWhisperModelInflight.delete(variant);
+      if (listeners.size === 0) progressListeners.delete(variant);
     });
+    ensureWhisperModelInflight.set(variant, pending);
   }
   try {
-    return await ensureWhisperModelInflight;
+    return await ensureWhisperModelInflight.get(variant)!;
   } finally {
-    if (options.onProgress) progressListeners.delete(options.onProgress);
+    if (options.onProgress) listeners.delete(options.onProgress);
   }
 }

--- a/packages/compute-worker/src/playback/generation-window.ts
+++ b/packages/compute-worker/src/playback/generation-window.ts
@@ -21,7 +21,11 @@
  * grind." The knob is kept so the trade-off can be revisited in one place.
  */
 export const TTS_PLAYBACK_BACKWARD_PAD = 0;
-export const DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW = 12;
+// Dialogue-heavy books need more ordinal runway because a single spoken unit
+// can be only a few words. The client presents the resulting runway in seconds;
+// this ordinal ceiling is intentionally generous while keeping generation
+// bounded and cancellable.
+export const DEFAULT_TTS_PLAYBACK_AHEAD_WINDOW = 48;
 
 export function generationFloorForCursor(cursorOrdinal: number): number {
   const cursor = Math.max(0, Math.floor(Number(cursorOrdinal) || 0));

--- a/packages/compute-worker/tests/unit/playback-audio-range.test.ts
+++ b/packages/compute-worker/tests/unit/playback-audio-range.test.ts
@@ -1,0 +1,45 @@
+import Fastify from 'fastify';
+import { expect, test, vi } from 'vitest';
+import { createTtsPlaybackToken } from '@openreader/tts/playback-token';
+import { registerPlaybackAudioRoutes } from '../../src/api/routes/playback/audio';
+import type { ComputeWorkerRouteContext } from '../../src/api/route-context';
+import type { PlaybackSessionReadModel } from '../../src/api/playback/session-read-model';
+import type { PlaybackSessionController } from '../../src/api/playback/session-controller';
+
+vi.mock('@openreader/tts/audio-format', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@openreader/tts/audio-format')>(),
+  getCbrSilenceFrameLengths: async () => [417, 418],
+}));
+
+test('answers the WebKit two-byte media probe with a bounded partial response', async () => {
+  const app = Fastify();
+  const session = {
+    sessionId: 'range-session', userId: 'user', storageUserId: 'user', documentId: 'doc',
+    status: 'running', expiresAt: Date.now() + 60_000, generationStartOrdinal: 0,
+    cursorOrdinal: 0, planObjectKey: 'plan.json', settingsJson: {},
+  };
+  const readObject = vi.fn(async () => Uint8Array.from([0xff, 0xfb, 0x90, 0x00]).buffer);
+  registerPlaybackAudioRoutes({
+    app, storage: { readObject }, markActivity: vi.fn(),
+  } as unknown as ComputeWorkerRouteContext, {
+    readSession: async () => session,
+    readPlanSegments: async () => [{ ordinal: 0, text: 'Ready audio.' }],
+    listCompletedDurations: async () => new Map([[0, 1000]]),
+    readSegmentState: async () => ({ status: 'completed', audioKey: 'audio.mp3' }),
+  } as unknown as PlaybackSessionReadModel, {} as PlaybackSessionController);
+  try {
+    const token = createTtsPlaybackToken({ ...session, exp: session.expiresAt }, process.env.TTS_PLAYBACK_TOKEN_SECRET!);
+    const response = await app.inject({
+      method: 'GET', url: `/v1/tts-playback/sessions/${session.sessionId}/audio?token=${token}`,
+      headers: { range: 'bytes=0-1' },
+    });
+    expect(response.statusCode).toBe(206);
+    expect(response.headers['accept-ranges']).toBe('bytes');
+    expect(response.headers['content-range']).toMatch(/^bytes 0-1\/\d+$/);
+    expect(response.headers['content-length']).toBe('2');
+    expect(response.rawPayload).toEqual(Buffer.from([0xff, 0xfb]));
+    expect(readObject).toHaveBeenCalledTimes(1);
+  } finally {
+    await app.close();
+  }
+});

--- a/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
+++ b/packages/compute-worker/tests/unit/playback-session-read-model.test.ts
@@ -139,19 +139,14 @@ describe('playback session read model', () => {
     expect(fixture.readSegmentMetadata).toHaveBeenCalledTimes(2);
   });
 
-  test('serves proportional timing for audio-first sidecars until exact alignment is visible', async () => {
+  test('does not invent word timing for audio-first sidecars', async () => {
     const fixture = createFixture();
     const audioFirst = { ...completedSidecar(0), alignment: null };
     fixture.sidecars.set(0, audioFirst);
 
     const audioFirstRows = await fixture.model.readSegmentIndexRows(session, { minOrdinal: 0, limit: 1 });
-    expect(audioFirstRows[0]?.alignmentSource).toBe('proportional');
-    const proportional = JSON.parse(audioFirstRows[0]?.alignmentJson ?? 'null') as {
-      words?: Array<{ text?: string; endSec?: number }>;
-    } | null;
-    expect(proportional?.words).toHaveLength(2);
-    expect(proportional?.words?.map((word) => word.text)).toEqual(['Segment', '0']);
-    expect(proportional?.words?.at(-1)?.endSec).toBe(1.2);
+    expect(audioFirstRows[0]?.alignmentSource).toBeNull();
+    expect(audioFirstRows[0]?.alignmentJson).toBeNull();
 
     fixture.sidecars.set(0, completedSidecar(0));
     const exactRows = await fixture.model.readSegmentIndexRows(session, { minOrdinal: 0, limit: 1 });
@@ -208,7 +203,7 @@ describe('playback session read model', () => {
     const durations = fixture.model.listCompletedDurations(deepSession, 10_000);
     await vi.waitFor(() => expect(fixture.listSegmentOrdinals).toHaveBeenCalledTimes(1));
     release([2, 9_000]);
-    expect((await timeline).map((row) => row.alignmentSource)).toEqual(['exact', 'proportional']);
+    expect((await timeline).map((row) => row.alignmentSource)).toEqual(['exact', null]);
     expect([...(await durations).keys()]).toEqual([2, 9_000]);
     expect(fixture.readSegmentMetadata).toHaveBeenCalledTimes(2);
 

--- a/packages/compute-worker/tests/unit/whisper-model-selection.test.ts
+++ b/packages/compute-worker/tests/unit/whisper-model-selection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import { resolveTtsLanguage } from '@openreader/tts/language';
+import {
+  getWhisperModelPaths,
+  resolveWhisperModelVariant,
+} from '../../src/inference/whisper/model';
+
+describe('Whisper alignment model selection', () => {
+  test('uses the English-only tiny model for English language tags', () => {
+    expect(resolveWhisperModelVariant('en')).toBe('tiny-english');
+    expect(resolveWhisperModelVariant('en-US')).toBe('tiny-english');
+    expect(resolveWhisperModelVariant('EN_gb')).toBe('tiny-english');
+  });
+
+  test('uses the English-only tiny model for Auto with a plain English voice', () => {
+    const resolvedLanguage = resolveTtsLanguage({
+      configuredLanguage: 'auto',
+      voice: 'F1',
+    });
+
+    expect(resolvedLanguage).toBe('en');
+    expect(resolveWhisperModelVariant(resolvedLanguage)).toBe('tiny-english');
+  });
+
+  test('keeps the multilingual base model for other or unknown languages', () => {
+    expect(resolveWhisperModelVariant('es')).toBe('base-multilingual');
+    expect(resolveWhisperModelVariant('fr-CA')).toBe('base-multilingual');
+    expect(resolveWhisperModelVariant()).toBe('base-multilingual');
+  });
+
+  test('stores each model in its own durable artifact directory', () => {
+    expect(getWhisperModelPaths('tiny-english').modelDir).toContain('whisper-tiny.en_timestamped');
+    expect(getWhisperModelPaths('base-multilingual').modelDir).toContain('whisper-base_timestamped');
+    expect(getWhisperModelPaths('tiny-english').modelDir)
+      .not.toBe(getWhisperModelPaths('base-multilingual').modelDir);
+  });
+});

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -21,6 +21,7 @@
     "./locator": "./src/locator.ts",
     "./instructions": "./src/instructions.ts",
     "./playback-token": "./src/playback-token.ts",
+    "./playback-buffer": "./src/playback-buffer.ts",
     "./playback-scope": "./src/playback-scope.ts",
     "./playback-cbr-layout": "./src/playback-cbr-layout.ts",
     "./types": "./src/types.ts",

--- a/packages/tts/src/playback-buffer.ts
+++ b/packages/tts/src/playback-buffer.ts
@@ -1,0 +1,40 @@
+/** Listening-time targets, shared by the player and the generation controller. */
+export const PLAYBACK_START_BUFFER_WALL_MS = 10_000;
+export const PLAYBACK_RECOVERY_BUFFER_WALL_MS = 20_000;
+export const PLAYBACK_REFILL_WALL_MS = 45_000;
+export const PLAYBACK_AHEAD_WALL_MS = 60_000;
+export const PLAYBACK_PROGRESS_TIMEOUT_MS = 120_000;
+
+export type PlaybackBufferSegment = { ordinal: number; durationMs: number; generated: boolean };
+
+export function measurePlaybackBuffer(input: {
+  segments: readonly PlaybackBufferSegment[];
+  startOrdinal: number;
+  offsetWithinStartSegmentMs?: number;
+  playbackRate?: number;
+}) {
+  const startIndex = input.segments.findIndex((segment) => segment.ordinal === input.startOrdinal);
+  let durationMs = 0;
+  let segmentCount = 0;
+  if (startIndex >= 0) {
+    for (const segment of input.segments.slice(startIndex)) {
+      if (!segment.generated || !Number.isFinite(segment.durationMs) || segment.durationMs <= 0) break;
+      durationMs += segment.durationMs;
+      segmentCount++;
+    }
+  }
+  const rate = Number.isFinite(input.playbackRate) && input.playbackRate! > 0 ? input.playbackRate! : 1;
+  const remainingMs = Math.max(0, durationMs - Math.max(0, input.offsetWithinStartSegmentMs ?? 0));
+  return {
+    durationMs: remainingMs,
+    wallMs: remainingMs / rate,
+    segmentCount,
+    reachedDocumentEnd: startIndex >= 0 && segmentCount > 0 && startIndex + segmentCount === input.segments.length,
+  };
+}
+
+export function isPlaybackBufferReady(input: Parameters<typeof measurePlaybackBuffer>[0] & { minimumWallMs?: number }) {
+  const buffer = measurePlaybackBuffer(input);
+  return buffer.segmentCount > 0 && (buffer.reachedDocumentEnd
+    || buffer.wallMs >= (input.minimumWallMs ?? PLAYBACK_START_BUFFER_WALL_MS));
+}

--- a/packages/tts/src/segments.ts
+++ b/packages/tts/src/segments.ts
@@ -3,14 +3,12 @@ import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { preprocessSentenceForAudio } from './nlp';
-import { normalizeUnicodeToken, segmentWords } from './language';
 import { locatorIdentityKey, normalizeLocator } from './locator';
 import { ffprobeAudio } from './probe';
 import type {
   TTSSegmentLocator,
   TTSSegmentSettings,
 } from './types';
-import type { TTSSentenceAlignment, TTSSentenceWord } from './types';
 
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== 'object') {
@@ -233,62 +231,4 @@ export async function probeAudioDurationMsFromBuffer(buffer: Buffer, signal?: Ab
       await rm(workDir, { recursive: true, force: true }).catch(() => {});
     }
   }
-}
-
-function alignWordsToText(
-  sentence: string,
-  language?: string,
-): Array<{ text: string; charStart: number; charEnd: number }> {
-  return segmentWords(sentence, language).map((token) => ({
-    text: token.text,
-    charStart: token.start,
-    charEnd: token.end,
-  }));
-}
-
-export function buildProportionalAlignment(input: {
-  sentence: string;
-  sentenceIndex: number;
-  durationMs: number;
-  language?: string;
-}): TTSSentenceAlignment {
-  const wordsWithOffsets = alignWordsToText(input.sentence, input.language);
-  if (wordsWithOffsets.length === 0 || input.durationMs <= 0) {
-    return {
-      sentence: input.sentence,
-      sentenceIndex: input.sentenceIndex,
-      words: [],
-    };
-  }
-
-  const weighted = wordsWithOffsets.map((word) => ({
-    ...word,
-    weight: Math.max(1, normalizeUnicodeToken(word.text).length),
-  }));
-  const totalWeight = weighted.reduce((sum, word) => sum + word.weight, 0);
-
-  let consumedMs = 0;
-  const alignedWords: TTSSentenceWord[] = weighted.map((word, index) => {
-    const remainingMs = Math.max(0, input.durationMs - consumedMs);
-    const sliceMs = index === weighted.length - 1
-      ? remainingMs
-      : Math.max(1, Math.round((input.durationMs * word.weight) / Math.max(1, totalWeight)));
-
-    const startMs = consumedMs;
-    consumedMs += Math.min(sliceMs, remainingMs);
-
-    return {
-      text: word.text,
-      startSec: startMs / 1000,
-      endSec: consumedMs / 1000,
-      charStart: word.charStart,
-      charEnd: word.charEnd,
-    };
-  });
-
-  return {
-    sentence: input.sentence,
-    sentenceIndex: input.sentenceIndex,
-    words: alignedWords,
-  };
 }

--- a/src/components/player/TTSPlayer.tsx
+++ b/src/components/player/TTSPlayer.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useTTS } from '@/contexts/TTSContext';
+import { measurePlaybackBuffer } from '@openreader/tts/playback-buffer';
 import {
   PlayIcon,
   PauseIcon,
@@ -43,6 +44,19 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
   const shownSec = previewSec ?? playbackTimeSec;
   const canSeek = playbackDurationSec > 0 && Boolean(playbackSeekLayout);
   const playbackControl = resolvePlaybackControlPresentation(isPlaying, playbackPhase);
+  const aheadBuffer = useMemo(() => {
+    if (!playbackSeekLayout || playbackSeekLayout.segments.length === 0) return null;
+    const segment = playbackSeekLayout.segments.find(
+      (entry) => playbackTimeSec * 1000 >= entry.startMs && playbackTimeSec * 1000 < entry.endMs,
+    );
+    if (!segment) return null;
+    return measurePlaybackBuffer({
+      segments: playbackSeekLayout.segments,
+      startOrdinal: segment.ordinal,
+      offsetWithinStartSegmentMs: Math.max(0, playbackTimeSec * 1000 - segment.startMs),
+      playbackRate: 1,
+    });
+  }, [playbackSeekLayout, playbackTimeSec]);
   const scrubberTrackBackground = useMemo(() => {
     if (!playbackSeekLayout || playbackSeekLayout.durationMs <= 0 || playbackSeekLayout.segments.length === 0) {
       return 'color-mix(in srgb, var(--foreground) 14%, transparent)';
@@ -189,6 +203,17 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
                 ?? `${formatPlaybackTime(shownSec)} / ${formatPlaybackTime(playbackDurationSec)}`
               : 'No readable text'}
           </div>
+          {aheadBuffer && (isPlaying || playbackPhase === 'buffering') && (
+            <div
+              className="text-[10px] text-soft tabular-nums whitespace-nowrap"
+              aria-live="polite"
+              aria-label={`${Math.floor(aheadBuffer.wallMs / 1000)} seconds ready ahead`}
+            >
+              {playbackPhase === 'buffering'
+                ? `Loading ahead · ${Math.floor(aheadBuffer.wallMs / 1000)}s ready`
+                : `${Math.floor(aheadBuffer.wallMs / 1000)}s ahead`}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/player/TTSPlayer.tsx
+++ b/src/components/player/TTSPlayer.tsx
@@ -75,16 +75,16 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
   }, [playbackSeekLayout]);
 
   return (
-    <div className="sticky bottom-0 z-30 w-full border-t border-line-soft bg-surface-solid backdrop-blur-sm" data-app-ttsbar>
+    <div className="sticky bottom-0 z-30 w-full border-t border-line-soft bg-surface-solid shadow-[0_-10px_30px_color-mix(in_srgb,var(--background)_45%,transparent)] backdrop-blur-sm sm:shadow-none" data-app-ttsbar>
       {/* Top Edge Scrubber bar */}
-      <div className="group/scrubber absolute -top-[5px] left-0 right-0 h-2.5 z-40">
+      <div className="group/scrubber absolute -top-2.5 left-0 right-0 z-40 h-5 sm:-top-[5px] sm:h-2.5">
         {/* Track Base Rail (Empty Track) */}
-        <div className="pointer-events-none absolute left-0 right-0 top-1/2 h-[2px] -translate-y-1/2 bg-line-soft transition-[height] duration-fast group-hover/scrubber:h-[4px] group-active/scrubber:h-[4px] rounded-full" />
+        <div className="pointer-events-none absolute left-0 right-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-line-soft transition-[height] duration-fast group-hover/scrubber:h-[4px] group-active/scrubber:h-[4px] sm:h-[2px]" />
         
         {/* Generated Segments Track */}
         <div
           aria-hidden
-          className="pointer-events-none absolute left-0 right-0 top-1/2 h-[2px] -translate-y-1/2 transition-[height] duration-fast group-hover/scrubber:h-[4px] group-active/scrubber:h-[4px] rounded-full"
+          className="pointer-events-none absolute left-0 right-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full transition-[height] duration-fast group-hover/scrubber:h-[4px] group-active/scrubber:h-[4px] sm:h-[2px]"
           style={{ background: scrubberTrackBackground }}
         />
         {/* Hidden active range slider overlay */}
@@ -110,14 +110,16 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
           }}
           className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent disabled:cursor-not-allowed disabled:opacity-40
             [&::-webkit-slider-runnable-track]:h-[2px] [&::-webkit-slider-runnable-track]:bg-transparent
-            [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-[3px] [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-accent [&::-webkit-slider-thumb]:-mt-[5px] [&::-webkit-slider-thumb]:transition-transform [&::-webkit-slider-thumb]:duration-fast
+            [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-1 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-accent [&::-webkit-slider-thumb]:-mt-[7px] [&::-webkit-slider-thumb]:transition-transform [&::-webkit-slider-thumb]:duration-fast
             [&::-webkit-slider-thumb]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--background)_70%,transparent),0_1px_6px_color-mix(in_srgb,var(--accent)_55%,transparent)]
             group-hover/scrubber:[&::-webkit-slider-thumb]:scale-y-125 group-active/scrubber:[&::-webkit-slider-thumb]:scale-y-150
+            sm:[&::-webkit-slider-thumb]:h-3 sm:[&::-webkit-slider-thumb]:w-[3px] sm:[&::-webkit-slider-thumb]:-mt-[5px]
             
-            [&::-moz-range-track]:h-[2px] [&::-moz-range-track]:bg-transparent
-            [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:w-[3px] [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-accent [&::-moz-range-thumb]:transition-transform [&::-moz-range-thumb]:duration-fast
+            [&::-moz-range-track]:h-[3px] [&::-moz-range-track]:bg-transparent sm:[&::-moz-range-track]:h-[2px]
+            [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-1 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-accent [&::-moz-range-thumb]:transition-transform [&::-moz-range-thumb]:duration-fast
             [&::-moz-range-thumb]:shadow-[0_0_0_1px_color-mix(in_srgb,var(--background)_70%,transparent),0_1px_6px_color-mix(in_srgb,var(--accent)_55%,transparent)]
-            group-hover/scrubber:[&::-moz-range-thumb]:scale-y-125 group-active/scrubber:[&::-moz-range-thumb]:scale-y-150"
+            group-hover/scrubber:[&::-moz-range-thumb]:scale-y-125 group-active/scrubber:[&::-moz-range-thumb]:scale-y-150
+            sm:[&::-moz-range-thumb]:h-3 sm:[&::-moz-range-thumb]:w-[3px]"
         />
         {/* Tooltip Popup */}
         {previewSec !== null && playbackDurationSec > 0 && (
@@ -132,29 +134,32 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
         )}
       </div>
 
-      {/* Main Single Row Controls Layout */}
-      <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-3 py-1.5 pb-[max(0.375rem,env(safe-area-inset-bottom))]">
+      <div className="mx-auto grid max-w-5xl grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] grid-rows-[auto_auto] items-center gap-x-2 gap-y-1 px-3 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] sm:flex sm:justify-between sm:gap-4 sm:py-1.5 sm:pb-[max(0.375rem,env(safe-area-inset-bottom))]">
         {/* Left side: Speed control & Voice control */}
-        <div className="flex items-center gap-1 flex-1 min-w-0 justify-start">
-          <SpeedControl
-            disabled={isProcessing}
-            setSpeedAndRestart={setSpeedAndRestart}
-            setAudioPlayerSpeedAndRestart={setAudioPlayerSpeedAndRestart}
-          />
-          <VoicesControl
-            availableVoices={availableVoices}
-            disabled={isProcessing}
-            setVoiceAndRestart={setVoiceAndRestart}
-          />
+        <div className="contents sm:flex sm:min-w-0 sm:flex-1 sm:items-center sm:justify-start sm:gap-1">
+          <div className="col-start-1 row-start-2 justify-self-start">
+            <SpeedControl
+              disabled={isProcessing}
+              setSpeedAndRestart={setSpeedAndRestart}
+              setAudioPlayerSpeedAndRestart={setAudioPlayerSpeedAndRestart}
+            />
+          </div>
+          <div className="col-start-3 row-start-2 justify-self-end">
+            <VoicesControl
+              availableVoices={availableVoices}
+              disabled={isProcessing}
+              setVoiceAndRestart={setVoiceAndRestart}
+            />
+          </div>
         </div>
 
         {/* Center: Primary playback controls */}
-        <div className="flex items-center gap-1.5">
+        <div className="col-start-2 row-start-2 flex items-center gap-2 sm:gap-1.5">
           <IconButton
             onClick={skipBackward}
             aria-label="Skip backward"
             disabled={isProcessing || !isPlaybackReady || !hasReadableContent}
-            className="relative"
+            className="relative h-9 w-9 rounded-full sm:h-8 sm:w-8 sm:rounded-md"
           >
             {isProcessing ? <LoadingSpinner /> : <SkipBackwardIcon className="w-5 h-5" />}
           </IconButton>
@@ -167,7 +172,7 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
             aria-label={playbackControl.ariaLabel}
             aria-busy={playbackControl.isPending}
             disabled={!isPlaying && (!isPlaybackReady || !hasReadableContent)}
-            className="relative"
+            className="relative h-11 w-11 rounded-full bg-accent text-background shadow-[0_3px_12px_color-mix(in_srgb,var(--accent)_35%,transparent)] hover:bg-secondary-accent hover:text-background sm:h-8 sm:w-8 sm:rounded-md sm:bg-transparent sm:text-soft sm:shadow-none sm:hover:bg-accent-wash sm:hover:text-accent"
           >
             {!hasReadableContent
               ? <PlayIcon className="w-5 h-5" />
@@ -182,22 +187,24 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
             onClick={skipForward}
             aria-label="Skip forward"
             disabled={isProcessing || !isPlaybackReady || !hasReadableContent}
-            className="relative"
+            className="relative h-9 w-9 rounded-full sm:h-8 sm:w-8 sm:rounded-md"
           >
             {isProcessing ? <LoadingSpinner /> : <SkipForwardIcon className="w-5 h-5" />}
           </IconButton>
         </div>
 
         {/* Right side: Page Navigator & Timer display */}
-        <div className="flex items-center gap-3 flex-1 justify-end">
+        <div className="contents sm:flex sm:flex-1 sm:items-center sm:justify-end sm:gap-3">
           {currentPage && numPages && (
-            <Navigator
-              currentPage={currentPage}
-              numPages={numPages}
-              skipToLocation={skipToLocation}
-            />
+            <div className="col-span-3 row-start-3 mt-0.5 justify-self-center sm:mt-0">
+              <Navigator
+                currentPage={currentPage}
+                numPages={numPages}
+                skipToLocation={skipToLocation}
+              />
+            </div>
           )}
-          <div className="text-[11px] text-soft font-mono tabular-nums select-none whitespace-nowrap">
+          <div className="col-span-2 col-start-1 row-start-1 justify-self-start whitespace-nowrap font-mono text-[11px] tabular-nums text-soft select-none">
             {hasReadableContent
               ? playbackControl.statusText
                 ?? `${formatPlaybackTime(shownSec)} / ${formatPlaybackTime(playbackDurationSec)}`
@@ -205,7 +212,7 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
           </div>
           {aheadBuffer && (isPlaying || playbackPhase === 'buffering') && (
             <div
-              className="text-[10px] text-soft tabular-nums whitespace-nowrap"
+              className="col-start-3 row-start-1 justify-self-end whitespace-nowrap rounded-full bg-accent-wash px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-accent sm:rounded-none sm:bg-transparent sm:px-0 sm:py-0 sm:font-normal sm:text-soft"
               aria-live="polite"
               aria-label={`${Math.floor(aheadBuffer.wallMs / 1000)} seconds ready ahead`}
             >

--- a/src/components/player/TTSPlayer.tsx
+++ b/src/components/player/TTSPlayer.tsx
@@ -26,6 +26,7 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
   const {
     isPlaying,
     playbackPhase,
+    audioSpeed,
     togglePlay,
     skipForward,
     skipBackward,
@@ -54,9 +55,9 @@ export default function TTSPlayer({ currentPage, numPages, isPlaybackReady = tru
       segments: playbackSeekLayout.segments,
       startOrdinal: segment.ordinal,
       offsetWithinStartSegmentMs: Math.max(0, playbackTimeSec * 1000 - segment.startMs),
-      playbackRate: 1,
+      playbackRate: audioSpeed,
     });
-  }, [playbackSeekLayout, playbackTimeSec]);
+  }, [audioSpeed, playbackSeekLayout, playbackTimeSec]);
   const scrubberTrackBackground = useMemo(() => {
     if (!playbackSeekLayout || playbackSeekLayout.durationMs <= 0 || playbackSeekLayout.segments.length === 0) {
       return 'color-mix(in srgb, var(--foreground) 14%, transparent)';

--- a/src/components/reader/ReaderLoader.tsx
+++ b/src/components/reader/ReaderLoader.tsx
@@ -13,14 +13,14 @@ export function ReaderLoader({ progress }: { progress?: ReaderBootstrapProgress 
   const modelPercent = modelTotalBytes > 0 ? Math.round((modelDownloadedBytes / modelTotalBytes) * 100) : null;
   const displayedPercent = progress?.phase === 'downloading-model' ? modelPercent : percent;
   const title = progress?.phase === 'downloading-model'
-    ? 'Downloading document model'
+    ? 'Preparing document model'
     : progress?.phase === 'merging'
     ? 'Finishing document structure'
     : progress
       ? 'Understanding document structure'
       : 'Opening document';
   const detail = progress?.phase === 'downloading-model'
-    ? 'This one-time download prepares PDF reading order on this device'
+    ? 'Preparing PDF reading order in the cloud'
     : progress
     ? 'Finding the reading order across each page'
     : 'Preparing your reader and saved position';
@@ -59,7 +59,7 @@ export function ReaderLoader({ progress }: { progress?: ReaderBootstrapProgress 
           {progress ? (
             <div className={styles.progressLabels}>
               <span>{progress.phase === 'downloading-model'
-                ? 'Downloading model'
+                ? 'Preparing model'
                 : totalPages > 0 ? `Page ${pagesParsed} of ${totalPages}` : 'Preparing the first page'}</span>
               <span>{progress.phase === 'merging'
                 ? 'Finishing structure'

--- a/src/contexts/TTSContext.tsx
+++ b/src/contexts/TTSContext.tsx
@@ -97,6 +97,7 @@ interface TTSContextType extends TTSPlaybackState {
   sentences: string[];
   currentSentenceOrdinal: number | null;
   playbackPhase: TtsPlaybackPhase;
+  audioSpeed: number;
   playbackTimeSec: number;
   playbackDurationSec: number;
   playbackSeekLayout: TtsPlaybackSeekLayout | null;
@@ -628,6 +629,7 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
     sentences,
     currentSentenceOrdinal: selectedOrdinal,
     playbackPhase,
+    audioSpeed,
     playbackTimeSec,
     playbackDurationSec: playbackSeekLayout ? playbackSeekLayout.durationMs / 1000 : 0,
     playbackSeekLayout,
@@ -678,6 +680,7 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
     startDocumentAudioExport,
     selectedOrdinal,
     playbackPhase,
+    audioSpeed,
     currDocPage,
     currDocPageNumber,
     currDocPages,

--- a/src/hooks/audio/usePlaybackForegroundSync.ts
+++ b/src/hooks/audio/usePlaybackForegroundSync.ts
@@ -157,11 +157,11 @@ export function usePlaybackForegroundSync(input: UsePlaybackForegroundSyncInput)
             : null;
           toast.loading(
             percent === null
-              ? 'Downloading word-timing model…'
-              : `Downloading word-timing model… ${percent}%`,
+              ? 'Preparing word-timing model in the cloud…'
+              : `Preparing word-timing model in the cloud… ${percent}%`,
             { id: MODEL_DOWNLOAD_TOAST_ID },
           );
-          // Audio is already available with proportional timing. Download-only
+          // Audio is already available without exact word timing. Download-only
           // progress does not change either playback read model, so avoid two
           // redundant HTTP reads for every model checkpoint.
           return;

--- a/src/hooks/audio/useTtsPlayback.ts
+++ b/src/hooks/audio/useTtsPlayback.ts
@@ -9,7 +9,6 @@ import {
 } from '@/types/tts';
 import {
   createTtsPlaybackSession,
-  getTtsPlaybackSeekLayout,
   type TtsPlaybackPlanPayload,
   type TtsPlaybackSeekLayout,
   type TtsPlaybackSessionPayload,
@@ -337,7 +336,9 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       startPlaybackForegroundSync(runId);
 
       const initialSeekLayout = await waitForPlaybackStartBuffer({
-        loadLayout: () => getTtsPlaybackSeekLayout(session.seekLayoutUrl).catch(() => null),
+        // Foreground SSE owns seek-layout refreshes. Startup waits on the latest
+        // snapshot it has delivered instead of creating a second HTTP poll loop.
+        loadLayout: () => Promise.resolve(latestSeekLayoutRef.current),
         isCurrent: () => runId === playbackRunIdRef.current,
         playbackRate: audioSpeed,
       });

--- a/src/hooks/audio/useTtsPlayback.ts
+++ b/src/hooks/audio/useTtsPlayback.ts
@@ -95,7 +95,17 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
   const playbackRequestAbortRef = useRef<AbortController | null>(null);
   const playbackRecoveryRef = useRef<ReturnType<typeof createPlaybackRecovery> | null>(null);
   const latestSeekLayoutRef = useRef(playbackSeekLayout);
-  useEffect(() => { latestSeekLayoutRef.current = playbackSeekLayout; }, [playbackSeekLayout]);
+  useEffect(() => {
+    const activeSessionId = playbackSessionRef.current?.sessionId;
+    if (playbackSeekLayout && activeSessionId && playbackSeekLayout.sessionId !== activeSessionId) return;
+    latestSeekLayoutRef.current = playbackSeekLayout;
+  }, [playbackSeekLayout]);
+  const setActivePlaybackSeekLayout = useCallback((layout: TtsPlaybackSeekLayout | null) => {
+    const activeSessionId = playbackSessionRef.current?.sessionId;
+    if (layout && (!activeSessionId || layout.sessionId !== activeSessionId)) return;
+    latestSeekLayoutRef.current = layout;
+    setPlaybackSeekLayout(layout);
+  }, [setPlaybackSeekLayout]);
   const checkRecovery = useCallback(() => { playbackRecoveryRef.current?.check(); }, []);
   const [playbackPhase, setPlaybackPhase] = useState<TtsPlaybackPhase>('idle');
   const {
@@ -138,7 +148,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     playbackRunIdRef,
     playbackSessionRef,
     refreshPlaybackTimeline,
-    setPlaybackSeekLayout,
+    setPlaybackSeekLayout: setActivePlaybackSeekLayout,
   });
   const onPendingSeekExpired = useCallback(() => {
     if (!isPlayingRef.current) {
@@ -207,15 +217,19 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     abortPlaybackRequest();
   }, [abortPlaybackRequest, playbackRunIdRef, stopPlaybackRecovery]);
 
-  const resetPlaybackSession = useCallback(() => {
+  const resetPlaybackSession = useCallback((options?: { clearSeekLayout?: boolean }) => {
     stopPlaybackRecovery();
     stopPlaybackForegroundSync();
     playbackActiveRef.current = false;
     playbackSessionRef.current = null;
     playbackRequestHeadersRef.current = null;
+    if (options?.clearSeekLayout) {
+      latestSeekLayoutRef.current = null;
+      setPlaybackSeekLayout(null);
+    }
     resetPlaybackProjection();
     setPlaybackPhase('idle');
-  }, [resetPlaybackProjection, stopPlaybackForegroundSync, stopPlaybackRecovery]);
+  }, [resetPlaybackProjection, setPlaybackSeekLayout, stopPlaybackForegroundSync, stopPlaybackRecovery]);
 
   const abortAudio = useCallback(() => {
     setWorkerPlaybackActive(false);
@@ -277,7 +291,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       return;
     }
 
-    resetPlaybackSession();
+    resetPlaybackSession({ clearSeekLayout: true });
     setPlaybackPhase('planning');
     clearAudioSource();
 
@@ -324,6 +338,8 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
         timelineUrl: session.timelineUrl,
         seekLayoutUrl: session.seekLayoutUrl,
       };
+      latestSeekLayoutRef.current = null;
+      setPlaybackSeekLayout(null);
       playbackRequestHeadersRef.current = headers;
       setPlaybackPhase('ready');
 
@@ -336,6 +352,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
       startPlaybackForegroundSync(runId);
 
       const initialSeekLayout = await waitForPlaybackStartBuffer({
+        sessionId: session.sessionId,
         // Foreground SSE owns seek-layout refreshes. Startup waits on the latest
         // snapshot it has delivered instead of creating a second HTTP poll loop.
         loadLayout: () => Promise.resolve(latestSeekLayoutRef.current),
@@ -343,7 +360,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
         playbackRate: audioSpeed,
       });
       if (runId !== playbackRunIdRef.current || !initialSeekLayout) return;
-      setPlaybackSeekLayout(initialSeekLayout);
+      setActivePlaybackSeekLayout(initialSeekLayout);
       await refreshPlaybackTimeline(session.timelineUrl);
       if (runId !== playbackRunIdRef.current) return;
 
@@ -465,6 +482,7 @@ export function useTtsPlayback(input: UseTtsPlaybackInput) {
     resetPlaybackSession,
     setIsPlaying,
     setPlaybackPhase,
+    setActivePlaybackSeekLayout,
     setPlaybackSeekLayout,
     setSelectedOrdinal,
     setWorkerPlaybackActive,

--- a/src/lib/client/tts/playback-control.ts
+++ b/src/lib/client/tts/playback-control.ts
@@ -1,6 +1,11 @@
 import type { TtsPlaybackPhase } from '@/types/tts';
+import {
+  isPlaybackBufferReady,
+  measurePlaybackBuffer,
+  PLAYBACK_START_BUFFER_WALL_MS,
+} from '@openreader/tts/playback-buffer';
 
-export const PLAYBACK_START_BUFFER_WALL_MS = 10_000;
+export { PLAYBACK_START_BUFFER_WALL_MS } from '@openreader/tts/playback-buffer';
 
 type PlaybackBufferSegment = {
   ordinal: number;
@@ -57,26 +62,14 @@ export function measurePlaybackStartBuffer(
   segments: PlaybackBufferSegment[],
   startOrdinal: number,
 ): PlaybackStartBuffer {
-  const start = Math.max(0, Math.floor(Number(startOrdinal) || 0));
-  const ordered = [...segments].sort((a, b) => a.ordinal - b.ordinal);
-  const startIndex = ordered.findIndex((segment) => segment.ordinal === start);
-  if (startIndex < 0) {
-    return { durationMs: 0, segmentCount: 0, reachedDocumentEnd: false };
-  }
-
-  let durationMs = 0;
-  let segmentCount = 0;
-  for (let index = startIndex; index < ordered.length; index += 1) {
-    const segment = ordered[index];
-    if (!segment.generated) break;
-    durationMs += Math.max(1, Math.floor(Number(segment.durationMs) || 0));
-    segmentCount += 1;
-  }
-
+  const result = measurePlaybackBuffer({
+    segments: [...segments].sort((a, b) => a.ordinal - b.ordinal),
+    startOrdinal,
+  });
   return {
-    durationMs,
-    segmentCount,
-    reachedDocumentEnd: startIndex + segmentCount >= ordered.length,
+    durationMs: result.durationMs,
+    segmentCount: result.segmentCount,
+    reachedDocumentEnd: result.reachedDocumentEnd,
   };
 }
 
@@ -87,25 +80,13 @@ export function isPlaybackStartBufferReady(input: {
   minimumWallMs?: number;
   offsetWithinStartSegmentMs?: number;
 }): boolean {
-  const buffer = measurePlaybackStartBuffer(input.segments, input.startOrdinal);
-  if (buffer.segmentCount === 0) return false;
-  if (buffer.reachedDocumentEnd) return true;
-
-  const playbackRate = Number.isFinite(input.playbackRate) && input.playbackRate > 0
-    ? input.playbackRate
-    : 1;
-  const minimumWallMs = Math.max(0, Math.floor(
-    input.minimumWallMs ?? PLAYBACK_START_BUFFER_WALL_MS,
-  ));
-  const playableDurationMs = Math.max(
-    0,
-    buffer.durationMs - Math.max(0, Math.floor(input.offsetWithinStartSegmentMs ?? 0)),
-  );
-  // Duration, not segment count, is the meaningful underrun protection. One
-  // long generated paragraph can provide more runway than several headings;
-  // requiring a second segment in that case only adds a full provider round
-  // trip before playback can begin.
-  return playableDurationMs >= minimumWallMs * playbackRate;
+  return isPlaybackBufferReady({
+    segments: input.segments,
+    startOrdinal: input.startOrdinal,
+    playbackRate: input.playbackRate,
+    minimumWallMs: input.minimumWallMs ?? PLAYBACK_START_BUFFER_WALL_MS,
+    offsetWithinStartSegmentMs: input.offsetWithinStartSegmentMs,
+  });
 }
 
 export async function waitForPlaybackStartBuffer<T extends PlaybackStartLayout>(input: {

--- a/src/lib/client/tts/playback-control.ts
+++ b/src/lib/client/tts/playback-control.ts
@@ -14,6 +14,7 @@ type PlaybackBufferSegment = {
 };
 
 type PlaybackStartLayout = {
+  sessionId?: string;
   status: string | null;
   generationStartOrdinal: number;
   segments: PlaybackBufferSegment[];
@@ -90,6 +91,7 @@ export function isPlaybackStartBufferReady(input: {
 }
 
 export async function waitForPlaybackStartBuffer<T extends PlaybackStartLayout>(input: {
+  sessionId: string;
   loadLayout: () => Promise<T | null>;
   isCurrent: () => boolean;
   playbackRate: number;
@@ -100,11 +102,12 @@ export async function waitForPlaybackStartBuffer<T extends PlaybackStartLayout>(
   for (;;) {
     if (!input.isCurrent()) return null;
     const layout = await input.loadLayout();
-    if (layout?.status === 'failed') {
+    const belongsToSession = layout?.sessionId === input.sessionId;
+    if (belongsToSession && layout.status === 'failed') {
       throw new Error('TTS playback generation failed before audio became ready');
     }
     if (
-      layout
+      belongsToSession
       && (layout.status === 'running' || layout.status === 'succeeded')
       && isPlaybackStartBufferReady({
         segments: layout.segments,

--- a/src/lib/client/tts/playback-grid.ts
+++ b/src/lib/client/tts/playback-grid.ts
@@ -116,8 +116,7 @@ export function normalizePlaybackGrid(value: unknown): TtsPlaybackGrid {
 }
 
 export function shouldRefreshPlaybackSegmentTiming(segment: TtsPlaybackGridSegment): boolean {
-  void segment;
-  return false;
+  return !segment.generated;
 }
 
 export function findPlaybackGridSegmentAtMs(

--- a/src/lib/client/tts/playback-grid.ts
+++ b/src/lib/client/tts/playback-grid.ts
@@ -14,7 +14,7 @@ export type TtsPlaybackGridSegment = {
   estimated: boolean;
   locator: TTSSegmentLocator | null;
   alignment: TTSSentenceAlignment | null;
-  alignmentSource: 'proportional' | 'exact' | null;
+  alignmentSource: 'exact' | null;
 };
 
 export type TtsPlaybackGrid = {
@@ -94,9 +94,9 @@ export function normalizePlaybackGrid(value: unknown): TtsPlaybackGrid {
           ? normalizeLocator(row.locator as TTSSegmentLocator)
           : null,
         alignment: row.alignment && typeof row.alignment === 'object' ? row.alignment as TTSSentenceAlignment : null,
-        alignmentSource: row.alignmentSource === 'proportional' || row.alignmentSource === 'exact'
-          ? row.alignmentSource
-          : null,
+    alignmentSource: row.alignmentSource === 'exact'
+      ? row.alignmentSource
+      : null,
       };
     })
     .filter((item): item is TtsPlaybackGridSegment => Boolean(item))
@@ -116,7 +116,8 @@ export function normalizePlaybackGrid(value: unknown): TtsPlaybackGrid {
 }
 
 export function shouldRefreshPlaybackSegmentTiming(segment: TtsPlaybackGridSegment): boolean {
-  return segment.generated === false || segment.alignmentSource === 'proportional';
+  void segment;
+  return false;
 }
 
 export function findPlaybackGridSegmentAtMs(

--- a/src/lib/server/compute-worker/protocol.ts
+++ b/src/lib/server/compute-worker/protocol.ts
@@ -120,7 +120,7 @@ export type TtsPlaybackCompletedSegment = {
   audioKey: string;
   durationMs: number;
   alignmentJson: string | null;
-  alignmentSource: 'proportional' | 'exact' | null;
+  alignmentSource: 'exact' | null;
   updatedAt: number | null;
 };
 

--- a/src/lib/server/tts/playback-plans.ts
+++ b/src/lib/server/tts/playback-plans.ts
@@ -104,7 +104,7 @@ export type TtsPlaybackGridSegment = {
   estimated: boolean;
   locator: TTSSegmentLocator | null;
   alignment: TTSSentenceAlignment | null;
-  alignmentSource: 'proportional' | 'exact' | null;
+  alignmentSource: 'exact' | null;
   updatedAt?: number | null;
 };
 
@@ -120,7 +120,7 @@ export function buildPlaybackGrid(input: {
   startOrdinal: number;
   completedSegments?: Map<number, {
     alignment: TTSSentenceAlignment | null;
-    alignmentSource: 'proportional' | 'exact' | null;
+    alignmentSource: 'exact' | null;
     updatedAt?: number | null;
   }>;
 }) {

--- a/src/types/tts.ts
+++ b/src/types/tts.ts
@@ -13,7 +13,7 @@ export type {
  * client heartbeats its cursor, so generation tracks the listener instead of
  * racing to the end of the document.
  */
-export const TTS_PLAYBACK_AHEAD_WINDOW = 12;
+export const TTS_PLAYBACK_AHEAD_WINDOW = 48;
 
 /**
  * How often the client POSTs its playback cursor while playing. Must be well

--- a/tests/unit/playback-buffer.vitest.spec.ts
+++ b/tests/unit/playback-buffer.vitest.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+import {
+  isPlaybackBufferReady,
+  measurePlaybackBuffer,
+  PLAYBACK_RECOVERY_BUFFER_WALL_MS,
+} from '@openreader/tts/playback-buffer';
+
+describe('playback ahead buffer', () => {
+  const segments = [
+    { ordinal: 4, durationMs: 3_000, generated: true },
+    { ordinal: 5, durationMs: 8_000, generated: true },
+    { ordinal: 6, durationMs: 20_000, generated: false },
+  ];
+
+  test('counts contiguous generated audio from the cursor and subtracts its offset', () => {
+    expect(measurePlaybackBuffer({
+      segments,
+      startOrdinal: 4,
+      offsetWithinStartSegmentMs: 1_000,
+      playbackRate: 1,
+    })).toMatchObject({ durationMs: 10_000, wallMs: 10_000, segmentCount: 2 });
+  });
+
+  test('scales runway by playback rate and stops at a cache hole', () => {
+    const buffer = measurePlaybackBuffer({ segments, startOrdinal: 4, playbackRate: 2 });
+    expect(buffer.wallMs).toBe(5_500);
+    expect(buffer.reachedDocumentEnd).toBe(false);
+    expect(isPlaybackBufferReady({
+      segments,
+      startOrdinal: 4,
+      playbackRate: 1,
+      minimumWallMs: PLAYBACK_RECOVERY_BUFFER_WALL_MS,
+    })).toBe(false);
+  });
+});

--- a/tests/unit/playback-control.vitest.spec.ts
+++ b/tests/unit/playback-control.vitest.spec.ts
@@ -151,27 +151,32 @@ describe('playback start buffer', () => {
   test('waits through partial layouts and stops when the requested run is replaced', async () => {
     const layouts = [
       {
+        sessionId: 'session-current',
         status: 'running',
         generationStartOrdinal: 50,
         segments: [segment(50, 2_000), segment(51, 9_000, false)],
       },
       {
+        sessionId: 'session-current',
         status: 'running',
         generationStartOrdinal: 50,
         segments: [segment(50, 2_000), segment(51, 9_000)],
       },
     ];
     expect(await waitForPlaybackStartBuffer({
+      sessionId: 'session-current',
       loadLayout: async () => layouts.shift() ?? null,
       isCurrent: () => true,
       playbackRate: 1,
       pollMs: 0,
     })).toEqual({
+      sessionId: 'session-current',
       status: 'running',
       generationStartOrdinal: 50,
       segments: [segment(50, 2_000), segment(51, 9_000)],
     });
     expect(await waitForPlaybackStartBuffer({
+      sessionId: 'session-current',
       loadLayout: async () => null,
       isCurrent: () => false,
       playbackRate: 1,
@@ -179,9 +184,39 @@ describe('playback start buffer', () => {
     })).toBeNull();
   });
 
+  test('ignores a ready layout from the previous playback session', async () => {
+    const layouts = [
+      {
+        sessionId: 'session-previous',
+        status: 'succeeded',
+        generationStartOrdinal: 10,
+        segments: [segment(10, 12_000)],
+      },
+      {
+        sessionId: 'session-current',
+        status: 'running',
+        generationStartOrdinal: 40,
+        segments: [segment(40, 12_000)],
+      },
+    ];
+
+    await expect(waitForPlaybackStartBuffer({
+      sessionId: 'session-current',
+      loadLayout: async () => layouts.shift() ?? null,
+      isCurrent: () => true,
+      playbackRate: 1,
+      pollMs: 0,
+    })).resolves.toMatchObject({
+      sessionId: 'session-current',
+      generationStartOrdinal: 40,
+    });
+  });
+
   test('fails immediately when generation reaches a terminal failure', async () => {
     await expect(waitForPlaybackStartBuffer({
+      sessionId: 'session-current',
       loadLayout: async () => ({
+        sessionId: 'session-current',
         status: 'failed',
         generationStartOrdinal: 60,
         segments: [segment(60, 8_000, false)],

--- a/tests/unit/playback-grid.vitest.spec.ts
+++ b/tests/unit/playback-grid.vitest.spec.ts
@@ -78,7 +78,7 @@ describe('playback grid mapping', () => {
     expect(normalized.segments.map((segment) => segment.audioState)).toEqual(['pending', 'ready']);
     expect(normalized.segments.map((segment) => segment.durationSource)).toEqual(['estimated', 'exact']);
     expect(normalized.segments.map((segment) => segment.alignmentSource)).toEqual([null, null]);
-    expect(shouldRefreshPlaybackSegmentTiming(normalized.segments[0])).toBe(false);
+    expect(shouldRefreshPlaybackSegmentTiming(normalized.segments[0])).toBe(true);
     expect(shouldRefreshPlaybackSegmentTiming(normalized.segments[1])).toBe(false);
     expect(shouldRefreshPlaybackSegmentTiming(grid.segments[1])).toBe(false);
   });

--- a/tests/unit/playback-grid.vitest.spec.ts
+++ b/tests/unit/playback-grid.vitest.spec.ts
@@ -70,16 +70,16 @@ describe('playback grid mapping', () => {
       generationStartOrdinal: 0,
       durationMs: 2000,
       segments: [
-        { ordinal: 1, segmentKey: 'b', startMs: 1000, endMs: 2000, durationMs: 1000, generated: true, alignmentSource: 'proportional' },
+        { ordinal: 1, segmentKey: 'b', startMs: 1000, endMs: 2000, durationMs: 1000, generated: true, alignmentSource: null },
         { ordinal: 0, segmentKey: 'a', startMs: 0, endMs: 1000, durationMs: 1000, estimated: true },
       ],
     });
     expect(normalized.segments.map((segment) => segment.ordinal)).toEqual([0, 1]);
     expect(normalized.segments.map((segment) => segment.audioState)).toEqual(['pending', 'ready']);
     expect(normalized.segments.map((segment) => segment.durationSource)).toEqual(['estimated', 'exact']);
-    expect(normalized.segments.map((segment) => segment.alignmentSource)).toEqual([null, 'proportional']);
-    expect(shouldRefreshPlaybackSegmentTiming(normalized.segments[0])).toBe(true);
-    expect(shouldRefreshPlaybackSegmentTiming(normalized.segments[1])).toBe(true);
+    expect(normalized.segments.map((segment) => segment.alignmentSource)).toEqual([null, null]);
+    expect(shouldRefreshPlaybackSegmentTiming(normalized.segments[0])).toBe(false);
+    expect(shouldRefreshPlaybackSegmentTiming(normalized.segments[1])).toBe(false);
     expect(shouldRefreshPlaybackSegmentTiming(grid.segments[1])).toBe(false);
   });
 

--- a/tests/unit/server-state-architecture.vitest.spec.ts
+++ b/tests/unit/server-state-architecture.vitest.spec.ts
@@ -392,7 +392,8 @@ describe('server-state architecture', () => {
     expect(context).toContain('resetBootstrapPlanAdoption();');
     expect(planController).not.toContain('attempt < 20');
     expect(planController.match(/getTtsPlaybackSeekLayout\(/g) ?? []).toHaveLength(1);
-    expect(playbackHook).toContain('getTtsPlaybackSeekLayout(session.seekLayoutUrl');
+    expect(playbackHook).not.toContain('getTtsPlaybackSeekLayout(session.seekLayoutUrl');
+    expect(playbackHook).toContain('startPlaybackForegroundSync(runId)');
     expect(planController).toContain('applyPlaybackPlan(plan)');
     expect(clientTts).not.toContain("fetch('/api/tts/playback/plans'");
     expect(clientTts).not.toContain('planOnly');
@@ -494,8 +495,7 @@ describe('server-state architecture', () => {
     expect(workerRoutes).not.toContain("/v1/tts-playback/:sessionId/audio");
     expect(workerRoutes).not.toContain("/v1/tts-playback-plans/operations");
     expect(workerRoutes).toContain("Readable.from(streamRange(), { objectMode: false, highWaterMark: 64 * 1024 })");
-    // The audio stream is seekable (range-capable + finite Content-Length) so the
-    // browser honors post-generation playbackRate, including on Safari.
+    // WebKit probes bytes=0-1 before playing. Keep the byte-range contract.
     expect(workerRoutes).toContain("reply.header('Accept-Ranges', 'bytes')");
     expect(workerRoutes).toContain('parseRangeHeader');
     expect(workerRoutes).toContain('verifyTtsPlaybackToken');

--- a/tests/unit/tts-segments.vitest.spec.ts
+++ b/tests/unit/tts-segments.vitest.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'vitest';
 import {
   buildTtsPlaybackSegmentAudioKey,
   buildTtsPlaybackSettingsHash,
-  buildProportionalAlignment,
   buildTtsPlaybackAudioContentHash,
   buildTtsSegmentSettingsJson,
   buildTtsSegmentSettingsHash,
@@ -233,44 +232,4 @@ describe('tts segment helpers', () => {
     });
   });
 
-  test('builds proportional alignment preserving order', () => {
-    const alignment = buildProportionalAlignment({
-      sentence: normalizeSegmentText('Hello world again'),
-      sentenceIndex: 5,
-      durationMs: 1500,
-    });
-    expect(alignment.sentenceIndex).toBe(5);
-    expect(alignment.words.length).toBe(3);
-    const first = alignment.words[0];
-    const second = alignment.words[1];
-    const third = alignment.words[2];
-    expect(first).toBeDefined();
-    expect(second).toBeDefined();
-    expect(third).toBeDefined();
-    expect(first!.startSec).toBe(0);
-    expect(third!.endSec).toBeGreaterThan(1.4);
-    expect(first!.charStart).toBeDefined();
-    expect(second!.charStart).toBeDefined();
-    const firstCharStart = first!.charStart;
-    const secondCharStart = second!.charStart;
-    if (firstCharStart === undefined || secondCharStart === undefined) {
-      throw new Error('Expected proportional alignment words to include charStart offsets');
-    }
-    expect(secondCharStart).toBeGreaterThan(firstCharStart);
-  });
-
-  test('builds proportional alignment for no-space languages', () => {
-    const sentence = 'これは日本語です';
-    const alignment = buildProportionalAlignment({
-      sentence,
-      sentenceIndex: 2,
-      durationMs: 1200,
-      language: 'ja',
-    });
-
-    expect(alignment.words.length).toBeGreaterThan(1);
-    for (const word of alignment.words) {
-      expect(sentence.slice(word.charStart, word.charEnd)).toBe(word.text);
-    }
-  });
 });

--- a/v5/PLAYBACK_ARCHITECTURE.md
+++ b/v5/PLAYBACK_ARCHITECTURE.md
@@ -281,6 +281,8 @@ For each planned segment:
 7. Enqueue that segment into one ordered alignment lane. The lane starts exact
    Whisper timing for the first playable segment while synthesis continues for
    the remaining ahead window; it never runs more than one alignment at once.
+   English language tags use the smaller timestamped Whisper tiny English model;
+   other and unknown languages use the multilingual timestamped base model.
 8. Replace the provisional sidecar timing with exact alignment and emit another
    progress snapshot. A paused, superseded, or cache-cleared generation run
    stops both further synthesis and timing backfills at the same ownership
@@ -320,11 +322,10 @@ Readiness is derived from sidecars:
 - The default `/segments` listing returns the complete discovered cached set;
   explicit-window requests still read only their requested ordinal window.
 
-When audio is ready before exact alignment, the timeline explicitly labels its
-word schedule as `proportional`. The client may use that schedule immediately,
-but continues refreshing the active segment until the worker returns `exact`
-timing. This preserves fast startup without allowing an entire EPUB ahead window
-to remain stuck on estimated word pacing.
+When audio is ready before exact alignment, the timeline omits word timing for
+that segment. The client starts audio without inventing a word schedule and
+shows word highlighting only after SSE announces progress and the refreshed
+timeline contains exact timing.
 
 ### Cursor Updates
 
@@ -1642,7 +1643,7 @@ that the local same-host acceptance runs did not exercise:
 
 - The live generation window was only eight segments and waited until half of
   that window remained before asking for a continuation. The active window is
-  now twelve segments and refills while roughly three quarters remain, giving
+  now forty-eight segments and refills while roughly three quarters remain, giving
   the provider, NATS, object storage, and browser heartbeat more recovery time
   without returning to per-segment enqueueing.
 - A bounded playback job kept its operation nonterminal while its ordered
@@ -1659,11 +1660,9 @@ that the local same-host acceptance runs did not exercise:
   checkpoints, and download-only snapshots update only the word-timing toast.
   Timeline and seek-layout reads remain driven by segment/audio or exact-timing
   changes.
-- The playback toast now calls this the `word-timing model`. Audio continues to
-  use proportional timing while the cold model downloads; visible highlighting
-  during that download is therefore not evidence that exact Whisper alignment
-  has already completed. Whisper artifact acquisition remains single-flight per
-  worker process.
+- The playback toast now calls this the `word-timing model`. Audio continues
+  without word highlighting while the cold model downloads. Whisper artifact
+  acquisition remains single-flight per model and worker process.
 - Cursor and play/pause sidecars now belong to a stable session incarnation,
   rather than the session's rolling expiry. The previous expiry equality check
   invalidated each cursor as soon as its heartbeat extended the TTL, so refill
@@ -1711,7 +1710,7 @@ and accumulated data, independently of inference CPU load:
 - Whole-document timeline/duration reads list existing sidecars for the exact
   user/document/version/settings scope, rather than probing every ordinal from
   zero to a deep cursor. Concurrent reads share an in-flight collection. Exact
-  sidecars stay cached across chapters; proportional sidecars are re-read until
+  sidecars stay cached across chapters; audio-only sidecars are re-read until
   exact timing is available. This preserves the complete generated-cache view.
 - Playback job startup uses the same scoped catalogue to discover completed
   segments. It no longer probes every ungenerated segment in the entire book


### PR DESCRIPTION
Slow production generation could exhaust the ready audio window, leave playback looking active during silence, and display estimated word highlighting before exact alignment arrived. Playback now waits for a duration-based ready window, reports its buffer through the existing SSE-backed state, and shows a clear loading-ahead state only when audio must stop.

This change also:

- expands forward generation from 12 to 48 segments while preserving the canonical playback session;
- removes proportional word timings so highlighting appears only after exact Whisper alignment;
- uses the pinned Whisper Tiny English timestamped model for resolved English language tags while retaining multilingual Whisper Base elsewhere;
- preserves byte-range audio responses used by WebKit playback probes;
- describes cold model preparation as cloud work rather than a device download; and
- gives phone-sized screens a dedicated two-row player with larger touch targets and a compact PDF navigation row.

Validation:

- `pnpm test` — 137 files and 686 tests passed
- `pnpm build`
- `pnpm exec tsc --noEmit`
- `pnpm --dir packages/compute-worker exec tsc --noEmit`
- `pnpm lint:route-errors`
- `pnpm check:compute-boundary`
- Real Tiny English inference returned exact timestamps for an English Supertonic sample
- Production browser check with delayed successful TTS responses showed `Loading ahead`, automatic recovery, and uninterrupted completion
- Production browser checks at 375×667 and 320×568 covered preparing and active playback layouts
